### PR TITLE
feat(logging): implement zerolog structured logging with trace ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,19 @@
 ## Active Technologies
 - **Language**: Go 1.25.5 (002-grpc-server-port)
 - **Storage**: N/A - stateless plugin (002-grpc-server-port)
+- Go 1.25.5 + zerolog v1.34.0, finfocus-spec v0.5.4 (pluginsdk) (003-zerolog-logging)
 
 ## Recent Changes
 - 002-grpc-server-port: Added Go 1.25.5
+
+## Zerolog
+
+ The constant already exists in finfocus-spec at sdk/go/pluginsdk/logging.go:24-25:
+
+  // TraceIDMetadataKey is the gRPC metadata header for trace ID propagation.
+  const TraceIDMetadataKey = "x-finfocus-trace-id"
+
+  Along with:
+  - TracingUnaryServerInterceptor() - server-side interceptor
+  - TraceIDFromContext(ctx) - context extraction
+  - ContextWithTraceID(ctx, traceID) - context storage

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Run the binary directly. It starts a gRPC server and outputs the port to stdout:
 
 ## Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `FINFOCUS_PLUGIN_PORT` | Fixed port number for the gRPC server | Ephemeral |
-| `FINFOCUS_LOG_LEVEL` | Log level: trace, debug, info, warn, error | info |
+| Variable               | Description                                   | Default   |
+|------------------------|-----------------------------------------------|-----------|
+| `FINFOCUS_PLUGIN_PORT` | Fixed port number for the gRPC server         | Ephemeral |
+| `FINFOCUS_LOG_LEVEL`   | Log level: trace, debug, info, warn, error    | info      |
 
 ### Examples
 
@@ -76,6 +76,43 @@ FINFOCUS_LOG_LEVEL=debug ./bin/finfocus-plugin-azure-public
 - **stdout**: Contains only the `PORT=XXXXX` line for discovery
 - **stderr**: Contains JSON-formatted structured logs
 
+### Log Format
+
+All logs are written to stderr in JSON format with the following fields:
+
+```json
+{
+  "level": "info",
+  "plugin_name": "azure-public",
+  "plugin_version": "1.0.0",
+  "time": "2026-02-02T10:00:00Z",
+  "message": "plugin started",
+  "trace_id": "abc-123"
+}
+```
+
+| Field            | Description                                                    |
+|------------------|----------------------------------------------------------------|
+| `level`          | Log severity: trace, debug, info, warn, error, fatal           |
+| `plugin_name`    | Always "azure-public"                                          |
+| `plugin_version` | Plugin version (or "dev" for development builds)               |
+| `time`           | RFC3339 timestamp                                              |
+| `message`        | Log message                                                    |
+| `trace_id`       | Request trace ID (only present when provided by FinFocus Core) |
+
+### Parsing Logs
+
+```bash
+# Parse with jq
+./bin/finfocus-plugin-azure-public 2>&1 | jq '.'
+
+# Filter by level
+./bin/finfocus-plugin-azure-public 2>&1 | jq 'select(.level == "error")'
+
+# Filter by trace ID
+./bin/finfocus-plugin-azure-public 2>&1 | jq 'select(.trace_id == "abc-123")'
+```
+
 ### Graceful Shutdown
 
 The plugin responds to SIGTERM and SIGINT signals for graceful shutdown:
@@ -88,14 +125,14 @@ kill -SIGTERM $PID  # Graceful shutdown, exit code 0
 
 ## Available Commands
 
-| Command | Description |
-|---------|-------------|
-| `make build` | Compile binary with version info |
-| `make test` | Run unit tests with race detection |
-| `make lint` | Run code quality checks |
-| `make clean` | Remove build artifacts |
-| `make ensure` | Install development dependencies |
-| `make help` | Show available targets |
+| Command        | Description                          |
+|----------------|--------------------------------------|
+| `make build`   | Compile binary with version info     |
+| `make test`    | Run unit tests with race detection   |
+| `make lint`    | Run code quality checks              |
+| `make clean`   | Remove build artifacts               |
+| `make ensure`  | Install development dependencies     |
+| `make help`    | Show available targets               |
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,35 +3,41 @@
 This roadmap outlines the development of the Azure Retail Pricing plugin for FinFocus. It follows the **Spec-Driven Development (Speckit)** workflow.
 
 ## Mission Statement
+
 To provide accurate, real-time Azure cost estimates for FinFocus by querying the Azure Retail Prices API, ensuring resilience and performance through intelligent caching and robust transport logic.
 
 ---
 
 ## Phase 1: Scaffold & Transport (v0.1.0)
+
 **Goal:** Establish the plugin structure, build system, and basic gRPC connectivity.
 
 **Milestone:** [v0.1.0 - Scaffold & Transport](https://github.com/rshade/finfocus-plugin-azure-public/milestone/1)
 
 **Issues:**
-- [#1](https://github.com/rshade/finfocus-plugin-azure-public/issues/1) Initialize Go module and project dependencies
-- [#2](https://github.com/rshade/finfocus-plugin-azure-public/issues/2) Setup Makefile with build, test, lint targets
-- [#3](https://github.com/rshade/finfocus-plugin-azure-public/issues/3) Configure CI pipeline (GitHub Actions)
-- [#4](https://github.com/rshade/finfocus-plugin-azure-public/issues/4) Implement gRPC server with port discovery
-- [#5](https://github.com/rshade/finfocus-plugin-azure-public/issues/5) Implement CostSourceService method stubs
-- [#6](https://github.com/rshade/finfocus-plugin-azure-public/issues/6) Implement zerolog structured logging
+
+- [x] [#1](https://github.com/rshade/finfocus-plugin-azure-public/issues/1) Initialize Go module and project dependencies
+- [x] [#2](https://github.com/rshade/finfocus-plugin-azure-public/issues/2) Setup Makefile with build, test, lint targets
+- [ ] [#3](https://github.com/rshade/finfocus-plugin-azure-public/issues/3) Configure CI pipeline (GitHub Actions)
+- [x] [#4](https://github.com/rshade/finfocus-plugin-azure-public/issues/4) Implement gRPC server with port discovery
+- [ ] [#5](https://github.com/rshade/finfocus-plugin-azure-public/issues/5) Implement CostSourceService method stubs
+- [ ] [#6](https://github.com/rshade/finfocus-plugin-azure-public/issues/6) Implement zerolog structured logging
 
 **Verification:**
+
 - Binary builds and starts successfully
 - PORT announcement appears on stdout
 - All logs output to stderr in JSON format
 - gRPC calls accepted without crashing
 
 ## Phase 2: The Azure Client (v0.2.0)
+
 **Goal:** Implement the HTTP client capable of querying the Azure Retail API reliably.
 
 **Milestone:** [v0.2.0 - Azure Client](https://github.com/rshade/finfocus-plugin-azure-public/milestone/2)
 
 **Issues:**
+
 - [#7](https://github.com/rshade/finfocus-plugin-azure-public/issues/7) Implement HTTP client with retry logic for Azure Retail Prices API
 - [#8](https://github.com/rshade/finfocus-plugin-azure-public/issues/8) Define Azure Retail Prices API data models
 - [#9](https://github.com/rshade/finfocus-plugin-azure-public/issues/9) Implement OData filter query builder
@@ -39,34 +45,40 @@ To provide accurate, real-time Azure cost estimates for FinFocus by querying the
 - [#11](https://github.com/rshade/finfocus-plugin-azure-public/issues/11) Implement comprehensive error handling for Azure API failures
 
 **Verification:**
+
 - Can query live Azure API for VM pricing
 - Pagination follows NextPageLink correctly
 - 429 errors trigger retry with backoff
 - Integration tests pass with live API
 
 ## Phase 3: The Caching Layer (v0.3.0)
+
 **Goal:** Prevent API throttling and improve performance for repetitive lookups.
 
 **Milestone:** [v0.3.0 - Caching Layer](https://github.com/rshade/finfocus-plugin-azure-public/milestone/3)
 
 **Issues:**
+
 - [#12](https://github.com/rshade/finfocus-plugin-azure-public/issues/12) Implement thread-safe in-memory cache
 - [#13](https://github.com/rshade/finfocus-plugin-azure-public/issues/13) Implement TTL-based cache eviction logic
 - [#14](https://github.com/rshade/finfocus-plugin-azure-public/issues/14) Implement cache key normalization
 - [#15](https://github.com/rshade/finfocus-plugin-azure-public/issues/15) Add cache observability (hit/miss metrics and logging)
 
 **Verification:**
+
 - 100 concurrent requests for same SKU show >80% cache hit rate
 - Race detector passes (go test -race)
 - Cache size stays bounded (LRU eviction works)
 - Cache metrics logged periodically
 
 ## Phase 4: Field Mapping & Estimation (v0.4.0)
+
 **Goal:** Connect the FinFocus generic `ResourceDescriptor` to Azure-specific queries.
 
 **Milestone:** [v0.4.0 - Field Mapping & Estimation](https://github.com/rshade/finfocus-plugin-azure-public/milestone/4)
 
 **Issues:**
+
 - [#16](https://github.com/rshade/finfocus-plugin-azure-public/issues/16) Implement ResourceDescriptor to Azure filter mapping
 - [#17](https://github.com/rshade/finfocus-plugin-azure-public/issues/17) Implement VM cost estimation (EstimateCost RPC)
 - [#18](https://github.com/rshade/finfocus-plugin-azure-public/issues/18) Implement Managed Disk cost estimation
@@ -74,6 +86,7 @@ To provide accurate, real-time Azure cost estimates for FinFocus by querying the
 - [#20](https://github.com/rshade/finfocus-plugin-azure-public/issues/20) Create integration tests with live Azure Retail Prices API
 
 **Verification:**
+
 - EstimateCost returns accurate costs for Standard_B1s VM
 - Managed Disk estimates scale with size
 - Estimates within 5% of Azure Pricing Calculator
@@ -145,14 +158,17 @@ each feature.
 ### v0.7.0+ - Advanced Features (Pending Research)
 
 **Database Services** (conditional on research):
+
 - Azure SQL Database cost estimation
 - Cosmos DB (RU/s-based pricing)
 
 **Advanced Pricing Models** (conditional on research):
+
 - Reserved Instances support
 - Savings Plans discount calculation
 
 **Sustainability** (conditional on research):
+
 - Carbon footprint estimation (aligned with AWS plugin)
 
 ### Out of Scope
@@ -167,11 +183,11 @@ The following features violate architectural constraints and are not planned:
 
 | Milestone                             | Status         | Progress   |
 | ------------------------------------- | -------------- | ---------- |
-| v0.1.0 - Scaffold & Transport         | 🔵 In Progress | 2/6 (33%)  |
+| v0.1.0 - Scaffold & Transport         | 🔵 In Progress | 3/6 (50%)  |
 | v0.2.0 - Azure Client                 | ⚪ Not Started  | 0/5 (0%)   |
 | v0.3.0 - Caching Layer                | ⚪ Not Started  | 0/4 (0%)   |
 | v0.4.0 - Field Mapping & Estimation   | ⚪ Not Started  | 0/5 (0%)   |
 
-**Completed Issues**: #1, #2
+**Completed Issues**: #1, #2, #4
 
-**Total Core Roadmap**: 20 issues across 4 phases (2 completed)
+**Total Core Roadmap**: 20 issues across 4 phases (3 completed)

--- a/internal/logging/request.go
+++ b/internal/logging/request.go
@@ -1,0 +1,36 @@
+// Package logging provides plugin-specific logging utilities.
+// This package wraps the pluginsdk logging functions for consistent usage patterns
+// across the Azure public pricing plugin.
+package logging
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+)
+
+// maxTraceIDLen is the maximum length of trace IDs to prevent log bloat from
+// malicious or buggy clients sending oversized values.
+const maxTraceIDLen = 128
+
+// RequestLogger creates a request-scoped logger with trace ID from context.
+// It uses pluginsdk.TraceIDFromContext to extract the trace ID from gRPC metadata.
+//
+// If a trace ID is present and non-empty, a child logger is returned with the
+// trace_id field added. If no trace ID is present (or it's empty), the base
+// logger is returned unchanged.
+//
+// Trace IDs longer than 128 characters are truncated to prevent log bloat.
+//
+// All existing fields on the base logger (plugin, version, etc.) are preserved.
+func RequestLogger(ctx context.Context, base zerolog.Logger) zerolog.Logger {
+	traceID := pluginsdk.TraceIDFromContext(ctx)
+	if traceID == "" {
+		return base
+	}
+	if len(traceID) > maxTraceIDLen {
+		traceID = traceID[:maxTraceIDLen]
+	}
+	return base.With().Str("trace_id", traceID).Logger()
+}

--- a/internal/logging/request_test.go
+++ b/internal/logging/request_test.go
@@ -1,0 +1,141 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+
+	"github.com/rshade/finfocus-plugin-azure-public/internal/logging"
+)
+
+func TestRequestLogger_WithTraceID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := zerolog.New(&buf).With().Str("plugin", "test").Logger()
+
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), "trace-123")
+	logger := logging.RequestLogger(ctx, base)
+
+	logger.Info().Msg("test message")
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to parse log output as JSON: %v", err)
+	}
+
+	if logEntry["trace_id"] != "trace-123" {
+		t.Errorf("expected trace_id=%q, got %q", "trace-123", logEntry["trace_id"])
+	}
+	if logEntry["plugin"] != "test" {
+		t.Errorf("expected plugin=%q, got %q", "test", logEntry["plugin"])
+	}
+}
+
+func TestRequestLogger_WithoutTraceID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := zerolog.New(&buf).With().Str("plugin", "test").Logger()
+
+	logger := logging.RequestLogger(context.Background(), base)
+	logger.Info().Msg("test message")
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to parse log output as JSON: %v", err)
+	}
+
+	if _, exists := logEntry["trace_id"]; exists {
+		t.Errorf("expected no trace_id field, but got %v", logEntry["trace_id"])
+	}
+	if logEntry["plugin"] != "test" {
+		t.Errorf("expected plugin=%q, got %q", "test", logEntry["plugin"])
+	}
+}
+
+func TestRequestLogger_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := zerolog.New(&buf).With().
+		Str("plugin", "azure-public").
+		Str("version", "1.0.0").
+		Logger()
+
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), "abc-456")
+	logger := logging.RequestLogger(ctx, base)
+
+	logger.Info().Msg("test message")
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to parse log output as JSON: %v", err)
+	}
+
+	if logEntry["plugin"] != "azure-public" {
+		t.Errorf("expected plugin=%q, got %q", "azure-public", logEntry["plugin"])
+	}
+	if logEntry["version"] != "1.0.0" {
+		t.Errorf("expected version=%q, got %q", "1.0.0", logEntry["version"])
+	}
+	if logEntry["trace_id"] != "abc-456" {
+		t.Errorf("expected trace_id=%q, got %q", "abc-456", logEntry["trace_id"])
+	}
+}
+
+func TestRequestLogger_EmptyTraceIDNotAdded(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := zerolog.New(&buf).With().Str("plugin", "test").Logger()
+
+	// Context with empty trace ID should not add trace_id field
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), "")
+	logger := logging.RequestLogger(ctx, base)
+
+	logger.Info().Msg("test message")
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to parse log output as JSON: %v", err)
+	}
+
+	if _, exists := logEntry["trace_id"]; exists {
+		t.Errorf("expected no trace_id field for empty string, but got %v", logEntry["trace_id"])
+	}
+}
+
+func TestRequestLogger_TruncatesLongTraceID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := zerolog.New(&buf).With().Str("plugin", "test").Logger()
+
+	// Create a trace ID longer than 128 characters
+	longTraceID := strings.Repeat("x", 200)
+
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), longTraceID)
+	logger := logging.RequestLogger(ctx, base)
+
+	logger.Info().Msg("test message")
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to parse log output as JSON: %v", err)
+	}
+
+	traceID, ok := logEntry["trace_id"].(string)
+	if !ok {
+		t.Fatalf("expected trace_id to be a string, got %T", logEntry["trace_id"])
+	}
+
+	if len(traceID) != 128 {
+		t.Errorf("expected trace_id to be truncated to 128 chars, got %d chars", len(traceID))
+	}
+}

--- a/internal/pricing/calculator.go
+++ b/internal/pricing/calculator.go
@@ -3,17 +3,24 @@ package pricing
 import (
 	"context"
 
+	"github.com/rs/zerolog"
 	finfocusv1 "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+
+	"github.com/rshade/finfocus-plugin-azure-public/internal/logging"
 )
 
 // Calculator implements finfocus.v1.CostSourceServiceServer.
 type Calculator struct {
 	finfocusv1.UnimplementedCostSourceServiceServer
+
+	logger zerolog.Logger
 }
 
-// NewCalculator creates a new instance of Calculator.
-func NewCalculator() *Calculator {
-	return &Calculator{}
+// NewCalculator creates a new instance of Calculator with the provided logger.
+func NewCalculator(logger zerolog.Logger) *Calculator {
+	return &Calculator{
+		logger: logger,
+	}
 }
 
 // Name returns the name of the plugin.
@@ -23,9 +30,12 @@ func (c *Calculator) Name() string {
 
 // GetPluginInfo returns metadata about the plugin.
 func (c *Calculator) GetPluginInfo(
-	_ context.Context,
+	ctx context.Context,
 	_ *finfocusv1.GetPluginInfoRequest,
 ) (*finfocusv1.GetPluginInfoResponse, error) {
+	log := logging.RequestLogger(ctx, c.logger)
+	log.Info().Msg("handling GetPluginInfo request")
+
 	return &finfocusv1.GetPluginInfoResponse{
 		Name:    "azure-public",
 		Version: "0.1.0",
@@ -34,8 +44,11 @@ func (c *Calculator) GetPluginInfo(
 
 // EstimateCost calculates the estimated cost for a given resource.
 func (c *Calculator) EstimateCost(
-	_ context.Context,
+	ctx context.Context,
 	_ *finfocusv1.EstimateCostRequest,
 ) (*finfocusv1.EstimateCostResponse, error) {
+	log := logging.RequestLogger(ctx, c.logger)
+	log.Info().Msg("handling EstimateCost request")
+
 	return &finfocusv1.EstimateCostResponse{}, nil
 }

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -1,21 +1,209 @@
 package pricing
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+	finfocusv1 "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func TestCalculatorName(t *testing.T) {
-	plugin := NewCalculator()
+	logger := zerolog.Nop()
+	plugin := NewCalculator(logger)
 	testPlugin := pluginsdk.NewTestPlugin(t, plugin)
 	testPlugin.TestName("azure-public")
+}
+
+func TestCalculatorLogIncludesTraceID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).With().Str("plugin_name", "azure-public").Logger()
+
+	calc := NewCalculator(logger)
+
+	// Create context with trace ID
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), "trace-abc-123")
+
+	// Call GetPluginInfo (which should log with trace ID)
+	_, err := calc.GetPluginInfo(ctx, &finfocusv1.GetPluginInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginInfo failed: %v", err)
+	}
+
+	// Parse log output
+	logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	traceFound := false
+	for _, line := range logLines {
+		if line == "" {
+			continue
+		}
+		var logEntry map[string]any
+		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
+			continue
+		}
+		if logEntry["trace_id"] == "trace-abc-123" {
+			traceFound = true
+			break
+		}
+	}
+
+	if !traceFound {
+		t.Errorf("expected trace_id in log output, got: %s", buf.String())
+	}
+}
+
+func TestCalculatorLogOmitsTraceIDWhenNotInContext(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).With().Str("plugin_name", "azure-public").Logger()
+
+	calc := NewCalculator(logger)
+
+	// Create context WITHOUT trace ID
+	ctx := context.Background()
+
+	// Call GetPluginInfo
+	_, err := calc.GetPluginInfo(ctx, &finfocusv1.GetPluginInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginInfo failed: %v", err)
+	}
+
+	// Parse log output - should NOT have trace_id field
+	logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for _, line := range logLines {
+		if line == "" {
+			continue
+		}
+		var logEntry map[string]any
+		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
+			continue
+		}
+		if _, exists := logEntry["trace_id"]; exists {
+			t.Errorf("expected no trace_id field when not in context, got: %s", line)
+		}
+	}
+}
+
+func TestEstimateCostLogIncludesTraceID(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).With().Str("plugin_name", "azure-public").Logger()
+
+	calc := NewCalculator(logger)
+
+	// Create context with trace ID
+	ctx := pluginsdk.ContextWithTraceID(context.Background(), "estimate-trace-456")
+
+	// Call EstimateCost (which should log with trace ID)
+	_, err := calc.EstimateCost(ctx, &finfocusv1.EstimateCostRequest{})
+	if err != nil {
+		t.Fatalf("EstimateCost failed: %v", err)
+	}
+
+	// Parse log output
+	logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	traceFound := false
+	for _, line := range logLines {
+		if line == "" {
+			continue
+		}
+		var logEntry map[string]any
+		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
+			continue
+		}
+		if logEntry["trace_id"] == "estimate-trace-456" {
+			traceFound = true
+			break
+		}
+	}
+
+	if !traceFound {
+		t.Errorf("expected trace_id in EstimateCost log output, got: %s", buf.String())
+	}
+}
+
+func TestCalculatorConcurrentRequestsMaintainSeparateTraceIDs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	logger := zerolog.New(zerolog.SyncWriter(&buf)).With().Str("plugin_name", "azure-public").Logger()
+
+	calc := NewCalculator(logger)
+
+	// Run concurrent requests with different trace IDs
+	var wg sync.WaitGroup
+	traceIDs := []string{"trace-1", "trace-2", "trace-3", "trace-4", "trace-5"}
+
+	// Use error channel to collect errors from goroutines safely
+	type testError struct {
+		traceID string
+		err     error
+	}
+	errCh := make(chan testError, len(traceIDs))
+
+	for _, traceID := range traceIDs {
+		wg.Add(1)
+		go func(tid string) {
+			defer wg.Done()
+			ctx := pluginsdk.ContextWithTraceID(context.Background(), tid)
+			_, err := calc.GetPluginInfo(ctx, &finfocusv1.GetPluginInfoRequest{})
+			if err != nil {
+				errCh <- testError{traceID: tid, err: err}
+			}
+		}(traceID)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// Report any errors collected from goroutines
+	for te := range errCh {
+		t.Errorf("GetPluginInfo failed for trace %s: %v", te.traceID, te.err)
+	}
+
+	// Verify each trace ID appears in logs
+	mu.Lock()
+	logContent := buf.String()
+	mu.Unlock()
+
+	logLines := strings.Split(strings.TrimSpace(logContent), "\n")
+	foundTraceIDs := make(map[string]bool)
+
+	for _, line := range logLines {
+		if line == "" {
+			continue
+		}
+		var logEntry map[string]any
+		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
+			continue
+		}
+		if tid, ok := logEntry["trace_id"].(string); ok {
+			foundTraceIDs[tid] = true
+		}
+	}
+
+	for _, expectedTID := range traceIDs {
+		if !foundTraceIDs[expectedTID] {
+			t.Errorf("trace_id %q not found in log output", expectedTID)
+		}
+	}
 }
 
 func TestProjectedCostSupported(t *testing.T) {
 	t.Skip("Skipping: GetProjectedCost not implemented yet. Azure pricing lookup requires implementation.")
 
-	plugin := NewCalculator()
+	logger := zerolog.Nop()
+	plugin := NewCalculator(logger)
 	testPlugin := pluginsdk.NewTestPlugin(t, plugin)
 
 	// Test supported resource
@@ -39,7 +227,8 @@ func TestProjectedCostSupported(t *testing.T) {
 }
 
 func TestProjectedCostUnsupported(t *testing.T) {
-	plugin := NewCalculator()
+	logger := zerolog.Nop()
+	plugin := NewCalculator(logger)
 	testPlugin := pluginsdk.NewTestPlugin(t, plugin)
 
 	// Test unsupported resource
@@ -48,7 +237,8 @@ func TestProjectedCostUnsupported(t *testing.T) {
 }
 
 func TestActualCost(t *testing.T) {
-	plugin := NewCalculator()
+	logger := zerolog.Nop()
+	plugin := NewCalculator(logger)
 	testPlugin := pluginsdk.NewTestPlugin(t, plugin)
 
 	// Test actual cost (should return error since not implemented)

--- a/specs/003-zerolog-logging/checklists/requirements.md
+++ b/specs/003-zerolog-logging/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Implement Zerolog Structured Logging
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The GitHub issue (#6) provided comprehensive technical notes that informed the functional requirements
+- The pluginsdk API is a known dependency from the reference AWS plugin implementation
+- Updated 2026-02-02: Added trace ID propagation requirements (FR-012 through FR-015, SC-007, SC-008, User Story 5)

--- a/specs/003-zerolog-logging/data-model.md
+++ b/specs/003-zerolog-logging/data-model.md
@@ -1,0 +1,145 @@
+# Data Model: Zerolog Structured Logging
+
+**Feature**: 003-zerolog-logging
+**Date**: 2026-02-02
+
+## Entities
+
+### Log Entry
+
+A single JSON log record emitted to stderr.
+
+**Fields**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `level` | string | Yes | Log severity: trace, debug, info, warn, error, fatal, panic |
+| `message` | string | Yes | Human-readable log message |
+| `time` | string | Yes | ISO 8601 timestamp (RFC3339 format) |
+| `plugin` | string | Yes | Plugin identifier: `azure-public` |
+| `version` | string | Yes | Plugin version (e.g., `1.0.0`, `dev`) |
+| `trace_id` | string | Conditional | Request trace ID from gRPC metadata (omitted if not present) |
+| `error` | string | No | Error message when logging errors |
+| `*` | any | No | Additional context fields (e.g., `port`, `region`, `resource_type`) |
+
+**Example Output**:
+
+```json
+{"level":"info","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:30:00Z","message":"plugin started"}
+{"level":"info","plugin":"azure-public","version":"1.0.0","trace_id":"abc123","time":"2026-02-02T10:30:01Z","message":"processing estimate cost request"}
+{"level":"error","plugin":"azure-public","version":"1.0.0","trace_id":"abc123","time":"2026-02-02T10:30:02Z","error":"azure api timeout","message":"failed to fetch pricing"}
+```
+
+**Validation Rules**:
+
+- `level` must be one of: trace, debug, info, warn, error, fatal, panic
+- `time` must be valid RFC3339 timestamp
+- `plugin` must always be `azure-public`
+- `trace_id` must not be empty string or null (omit field entirely if no trace)
+
+### Log Level
+
+Enumeration controlling log visibility.
+
+**Values** (ordered by severity, lowest to highest):
+
+| Level | Numeric | Use Case |
+|-------|---------|----------|
+| trace | -1 | Fine-grained debugging (rarely used) |
+| debug | 0 | Development debugging, internal state |
+| info | 1 | Normal operation events (default) |
+| warn | 2 | Recoverable issues, deprecation warnings |
+| error | 3 | Errors that don't crash the plugin |
+| fatal | 4 | Unrecoverable errors (causes exit) |
+| panic | 5 | Programming errors (causes panic) |
+
+**Behavior**: Setting level to X suppresses all messages with severity < X.
+
+### Trace ID
+
+Unique identifier for request correlation across services.
+
+**Attributes**:
+
+| Attribute | Value |
+|-----------|-------|
+| Source | gRPC incoming metadata |
+| Key | `pluginsdk.TraceIDMetadataKey` (`x-finfocus-trace-id`) |
+| Extraction | `pluginsdk.TraceIDFromContext(ctx)` (SDK function) |
+| Format | Opaque string (no validation) |
+| Lifecycle | Extracted per-request via SDK, attached to request-scoped logger |
+
+**Propagation Flow**:
+
+```text
+FinFocus Core                    Plugin
+     |                              |
+     |-- gRPC request ------------->|
+     |   metadata:                  |
+     |   x-finfocus-trace-id: abc   |
+     |                              |
+     |                    pluginsdk.TraceIDFromContext(ctx)
+     |                    logging.RequestLogger(ctx, base)
+     |                    All logs include trace_id: "abc"
+     |                              |
+     |<-- gRPC response ------------|
+```
+
+## State Transitions
+
+### Logger Lifecycle
+
+```text
+[Startup]
+    |
+    v
+[Base Logger Created]  -- pluginsdk.NewPluginLogger()
+    |                     Fields: plugin, version
+    |
+    v
+[Logger Injected]      -- NewCalculator(logger)
+    |                     Calculator stores logger
+    |
+    +-- [Per Request] --+
+    |                   |
+    |                   v
+    |           [Request Logger]    -- logging.RequestLogger(ctx, base)
+    |                   |              Uses: pluginsdk.TraceIDFromContext(ctx)
+    |                   |              Fields: plugin, version, trace_id (if present)
+    |                   |
+    |                   v
+    |           [Log Events]        -- log.Info().Msg(...)
+    |                   |
+    +-------------------+
+    |
+    v
+[Shutdown]             -- logger.Info().Msg("shutdown complete")
+```
+
+## Relationships
+
+```text
+┌─────────────┐     creates      ┌─────────────┐
+│   main()    │ ───────────────► │ Base Logger │
+└─────────────┘                  └─────────────┘
+                                       │
+                                       │ injected into
+                                       ▼
+                                 ┌─────────────┐
+                                 │ Calculator  │
+                                 └─────────────┘
+                                       │
+                                       │ per-request via
+                                       │ logging.RequestLogger()
+                                       ▼
+                                 ┌─────────────┐     SDK extracts  ┌──────────┐
+                                 │Request      │ ◄──────────────── │ Trace ID │
+                                 │Logger       │   pluginsdk.      └──────────┘
+                                 └─────────────┘   TraceIDFromContext()
+                                       │
+                                       │ emits
+                                       ▼
+                                 ┌─────────────┐
+                                 │ Log Entry   │ ──► stderr (JSON)
+                                 └─────────────┘
+```

--- a/specs/003-zerolog-logging/plan.md
+++ b/specs/003-zerolog-logging/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Implement Zerolog Structured Logging
+
+**Branch**: `003-zerolog-logging` | **Date**: 2026-02-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-zerolog-logging/spec.md`
+
+## Summary
+
+Implement structured JSON logging using zerolog with trace ID propagation for distributed tracing. The plugin already has basic logger initialization in `main.go` using `pluginsdk.NewPluginLogger`. This feature extends the implementation to:
+
+1. Pass the logger to the `Calculator` struct for use in RPC handlers
+2. Create `internal/logging` package with plugin-specific helpers that wrap SDK functions
+3. Use `pluginsdk.TraceIDFromContext(ctx)` for trace ID extraction (not re-implement)
+4. Provide `RequestLogger(ctx, base)` helper for consistent request-scoped logging
+5. Ensure all logs go to stderr with required fields (level, message, time, plugin, version, trace_id)
+
+### SDK Functions Used (from finfocus-spec/sdk/go/pluginsdk/logging.go)
+
+- `pluginsdk.TraceIDMetadataKey` - constant: `x-finfocus-trace-id`
+- `pluginsdk.TraceIDFromContext(ctx)` - extract trace ID from context
+- `pluginsdk.ContextWithTraceID(ctx, traceID)` - store trace ID in context
+- `pluginsdk.TracingUnaryServerInterceptor()` - server interceptor (optional)
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: zerolog v1.34.0, finfocus-spec v0.5.4 (pluginsdk)
+**Storage**: N/A - stateless plugin
+**Testing**: go test with race detector, table-driven tests
+**Target Platform**: Linux server (gRPC plugin for FinFocus Core)
+**Project Type**: Single project (Go plugin)
+**Performance Goals**: <1ms logging overhead, <10ms cache hits, <2s p95 API calls
+**Constraints**: All logs to stderr only, stdout reserved for `PORT=XXXX`
+**Scale/Scope**: Single plugin, ~6 Go files affected
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with `.specify/memory/constitution.md`:
+
+- [x] **Code Quality**: Plan includes linting checks (`make lint`), error handling for invalid log levels (fallback to info), low complexity (logger injection pattern)
+- [x] **Testing**: Plan includes TDD workflow, ≥80% coverage for logger helper functions, tests for trace ID extraction
+- [x] **User Experience**: Plan addresses observability (this IS the observability feature), structured JSON logging to stderr, no stdout pollution
+- [x] **Documentation**: Plan includes godoc for exported logger helpers, README updates for FINFOCUS_LOG_LEVEL env var
+- [x] **Performance**: Zerolog is zero-allocation in hot paths (<1ms overhead), no impact on existing performance targets
+- [x] **Architectural Constraints**: Plan DOES NOT violate "Hard No's":
+  - ✅ No authenticated Azure APIs (logging is internal)
+  - ✅ No persistent storage (logs to stderr stream)
+  - ✅ No infrastructure mutation (read-only logging)
+  - ✅ No bulk data embedding (no pricing data in logs)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-zerolog-logging/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: Research findings
+├── data-model.md        # Phase 1: Log entry schema
+├── quickstart.md        # Phase 1: Usage examples
+└── contracts/           # Phase 1: N/A (no external API changes)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/finfocus-plugin-azure-public/
+├── main.go              # MODIFY: Pass logger to Calculator
+└── main_test.go         # MODIFY: Add logger tests
+
+internal/
+├── logging/             # NEW: Plugin-specific logger utilities (wraps SDK)
+│   ├── request.go       # RequestLogger helper using pluginsdk.TraceIDFromContext
+│   └── request_test.go  # Unit tests for request logger helper
+└── pricing/
+    ├── calculator.go    # MODIFY: Accept logger, use in RPC handlers
+    └── calculator_test.go # MODIFY: Test logging behavior
+```
+
+**Structure Decision**: Single project structure maintained. New `internal/logging` package provides plugin-specific helpers that wrap SDK functions, enabling:
+
+- Consistent request-scoped logger creation across all RPC handlers
+- Future extensibility for plugin-specific context fields (region, resource_type)
+- Cleaner separation of concerns from pricing logic
+- Easier unit testing of logging behavior
+
+## Complexity Tracking
+
+No constitution violations requiring justification. Implementation follows standard Go patterns:
+
+- Logger injection via constructor (idiomatic Go)
+- SDK-based trace ID extraction via `pluginsdk.TraceIDFromContext` (reuse, don't reimplement)
+- Thin wrapper pattern for plugin-specific helpers
+- Zerolog's built-in JSON formatting (no custom logic)

--- a/specs/003-zerolog-logging/quickstart.md
+++ b/specs/003-zerolog-logging/quickstart.md
@@ -1,0 +1,132 @@
+# Quickstart: Zerolog Structured Logging
+
+**Feature**: 003-zerolog-logging
+**Date**: 2026-02-02
+
+## Overview
+
+This feature implements structured JSON logging for the Azure public pricing plugin. All logs are written to stderr in JSON format, with support for trace ID propagation from FinFocus Core.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FINFOCUS_LOG_LEVEL` | `info` | Log level (trace, debug, info, warn, error, fatal, panic) |
+| `LOG_LEVEL` | `info` | Fallback if `FINFOCUS_LOG_LEVEL` not set |
+
+### Log Level Priority
+
+1. `FINFOCUS_LOG_LEVEL` (highest priority)
+2. `LOG_LEVEL` (fallback)
+3. `info` (default)
+
+## Usage Examples
+
+### Example 1: Default Logging (Info Level)
+
+```bash
+# Run plugin with default settings
+./finfocus-plugin-azure-public
+
+# stderr output:
+{"level":"info","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:00Z","message":"plugin started"}
+{"level":"info","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:00Z","message":"server listening","port":50051}
+```
+
+### Example 2: Debug Logging
+
+```bash
+# Enable debug logging
+FINFOCUS_LOG_LEVEL=debug ./finfocus-plugin-azure-public
+
+# stderr output includes debug messages:
+{"level":"debug","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:00Z","message":"using ephemeral port"}
+{"level":"info","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:00Z","message":"plugin started"}
+{"level":"debug","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:00Z","message":"health check endpoint ready"}
+```
+
+### Example 3: Error-Only Logging (Production)
+
+```bash
+# Suppress info/debug, show only errors
+FINFOCUS_LOG_LEVEL=error ./finfocus-plugin-azure-public
+
+# stderr output (quiet unless errors occur):
+# (no output during normal operation)
+
+# On error:
+{"level":"error","plugin":"azure-public","version":"1.0.0","time":"2026-02-02T10:00:05Z","error":"connection refused","message":"azure api request failed"}
+```
+
+### Example 4: Trace ID Propagation
+
+When FinFocus Core sends requests with trace IDs, all related logs include the trace ID:
+
+```bash
+# FinFocus Core sends gRPC request with metadata:
+# x-finfocus-trace-id: req-abc-123
+
+# stderr output shows trace_id in all request logs:
+{"level":"info","plugin":"azure-public","version":"1.0.0","trace_id":"req-abc-123","time":"2026-02-02T10:00:01Z","message":"processing estimate cost request"}
+{"level":"debug","plugin":"azure-public","version":"1.0.0","trace_id":"req-abc-123","time":"2026-02-02T10:00:02Z","message":"fetching pricing data","resource_type":"Microsoft.Compute/virtualMachines"}
+{"level":"info","plugin":"azure-public","version":"1.0.0","trace_id":"req-abc-123","time":"2026-02-02T10:00:03Z","message":"estimate cost request completed"}
+```
+
+### Example 5: Parsing Logs with jq
+
+```bash
+# Run plugin and parse JSON logs
+./finfocus-plugin-azure-public 2>&1 | jq '.'
+
+# Filter by log level
+./finfocus-plugin-azure-public 2>&1 | jq 'select(.level == "error")'
+
+# Filter by trace ID
+./finfocus-plugin-azure-public 2>&1 | jq 'select(.trace_id == "req-abc-123")'
+
+# Extract only messages
+./finfocus-plugin-azure-public 2>&1 | jq -r '.message'
+```
+
+## Log Entry Schema
+
+Every log entry contains:
+
+```json
+{
+  "level": "info",           // Required: trace|debug|info|warn|error|fatal|panic
+  "message": "...",          // Required: Human-readable message
+  "time": "2026-...",        // Required: RFC3339 timestamp
+  "plugin": "azure-public",  // Required: Plugin identifier
+  "version": "1.0.0",        // Required: Plugin version
+  "trace_id": "...",         // Conditional: Present only if trace ID in request
+  "error": "...",            // Optional: Error details
+  // ... additional context fields
+}
+```
+
+## Stdout vs Stderr
+
+| Stream | Content |
+|--------|---------|
+| stdout | `PORT=XXXXX` only (for FinFocus Core discovery) |
+| stderr | All JSON log messages |
+
+**Important**: Never mix logs with stdout output. FinFocus Core parses stdout to discover the plugin port.
+
+## Testing Log Output
+
+```bash
+# Verify JSON format
+./finfocus-plugin-azure-public 2>&1 | head -1 | jq . && echo "Valid JSON"
+
+# Verify required fields
+./finfocus-plugin-azure-public 2>&1 | head -1 | jq 'has("level", "message", "time", "plugin", "version")'
+# Output: true
+
+# Verify no stdout pollution (should only see PORT=)
+./finfocus-plugin-azure-public 2>/dev/null
+# Output: PORT=50051
+```

--- a/specs/003-zerolog-logging/research.md
+++ b/specs/003-zerolog-logging/research.md
@@ -1,0 +1,143 @@
+# Research: Zerolog Structured Logging
+
+**Feature**: 003-zerolog-logging
+**Date**: 2026-02-02
+
+## Research Tasks
+
+### 1. Zerolog Best Practices for gRPC Services
+
+**Decision**: Use zerolog's context-based logging with `logger.With()` for request-scoped fields.
+
+**Rationale**:
+
+- Zerolog's `With()` method creates a child logger with additional fields without allocation
+- Each RPC handler receives a logger with trace ID pre-populated
+- Child loggers inherit all parent fields (plugin, version) automatically
+
+**Alternatives Considered**:
+
+- Global logger with manual field addition per log call: Rejected - verbose, error-prone
+- Context value for logger: Considered but unnecessary given struct injection pattern
+
+### 2. Trace ID Extraction from gRPC Metadata
+
+**Decision**: Use existing `pluginsdk.TraceIDFromContext(ctx)` from finfocus-spec SDK - do not reimplement.
+
+**Rationale**:
+
+- SDK already provides complete implementation in `sdk/go/pluginsdk/logging.go`
+- Consistent with other FinFocus plugins
+- Reduces code duplication and maintenance burden
+- SDK also provides `TracingUnaryServerInterceptor()` for automatic extraction
+
+**SDK Functions Available** (from `finfocus-spec/sdk/go/pluginsdk/logging.go:24-25`):
+
+```go
+// Already implemented in SDK - DO NOT REIMPLEMENT
+const TraceIDMetadataKey = "x-finfocus-trace-id"
+
+func TraceIDFromContext(ctx context.Context) string      // Extract trace ID
+func ContextWithTraceID(ctx, traceID) context.Context    // Store trace ID
+func TracingUnaryServerInterceptor() grpc.UnaryServerInterceptor  // Auto-extract
+```
+
+**Plugin-Specific Helper** (wraps SDK):
+
+```go
+// internal/logging/request.go - thin wrapper for plugin use
+package logging
+
+import (
+    "context"
+    "github.com/rs/zerolog"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+)
+
+// RequestLogger creates a request-scoped logger with trace ID from context.
+func RequestLogger(ctx context.Context, base zerolog.Logger) zerolog.Logger {
+    traceID := pluginsdk.TraceIDFromContext(ctx)
+    if traceID == "" {
+        return base
+    }
+    return base.With().Str("trace_id", traceID).Logger()
+}
+```
+
+**Alternatives Considered**:
+
+- Reimplement extraction: Rejected - SDK already has it, violates DRY
+- Use SDK directly in handlers: Works but less readable/extensible
+- OpenTelemetry trace context: Overkill for current requirements
+
+### 3. Logger Injection Pattern
+
+**Decision**: Inject logger into `Calculator` struct via constructor, create request-scoped loggers in RPC handlers.
+
+**Rationale**:
+
+- Constructor injection is idiomatic Go
+- Allows testing with mock/buffer loggers
+- Request-scoped loggers ensure trace ID isolation
+
+**Implementation Pattern**:
+
+```go
+type Calculator struct {
+    logger zerolog.Logger
+    // ... other fields
+}
+
+func NewCalculator(logger zerolog.Logger) *Calculator {
+    return &Calculator{logger: logger}
+}
+
+func (c *Calculator) EstimateCost(ctx context.Context, req *Request) (*Response, error) {
+    // Create request-scoped logger with trace ID using helper
+    log := logging.RequestLogger(ctx, c.logger)
+    log.Info().Msg("processing estimate cost request")
+    // ...
+}
+```
+
+**Alternatives Considered**:
+
+- Global logger: Rejected - hard to test, no request isolation
+- Logger in context: Unnecessary given struct injection works well
+
+### 4. Log Level Environment Variable Handling
+
+**Decision**: Use existing `pluginsdk.GetLogLevel()` which handles `FINFOCUS_LOG_LEVEL` > `LOG_LEVEL` > default `info`.
+
+**Rationale**:
+
+- SDK already implements the env var priority logic
+- Consistent with other FinFocus plugins (reference AWS plugin)
+- No additional code needed in this plugin
+
+**Verification**: Current `main.go` already uses this pattern correctly.
+
+### 5. Stderr-Only Output Guarantee
+
+**Decision**: Zerolog configured to write to `os.Stderr` by default via `pluginsdk.NewPluginLogger`.
+
+**Rationale**:
+
+- SDK function handles stderr configuration
+- No risk of stdout pollution
+- PORT announcement remains the only stdout output
+
+**Verification**: `pluginsdk.NewPluginLogger` returns logger configured with `zerolog.New(os.Stderr)`.
+
+## Resolved Clarifications
+
+| Unknown | Resolution | Source |
+|---------|------------|--------|
+| Trace ID metadata key | `x-finfocus-trace-id` | User clarification (2026-02-02) |
+| Trace ID extraction | Use `pluginsdk.TraceIDFromContext(ctx)` | SDK: logging.go:24-25 |
+| Log level priority | `FINFOCUS_LOG_LEVEL` > `LOG_LEVEL` > `info` | pluginsdk implementation |
+| Logger injection point | `Calculator` constructor | Existing codebase pattern |
+
+## No Further Research Needed
+
+All technical unknowns have been resolved. SDK provides core trace ID functionality - plugin adds thin wrapper for consistent usage pattern. Ready for Phase 1 design.

--- a/specs/003-zerolog-logging/spec.md
+++ b/specs/003-zerolog-logging/spec.md
@@ -1,0 +1,195 @@
+# Feature Specification: Implement Zerolog Structured Logging
+
+**Feature Branch**: `003-zerolog-logging`
+**Created**: 2026-02-02
+**Status**: Draft
+**Input**: GitHub Issue #6 - Configure zerolog for structured JSON logging to stderr with log level control via environment variables
+
+## Clarifications
+
+### Session 2026-02-02
+
+- Q: What is the gRPC metadata key for trace ID propagation? → A: `x-finfocus-trace-id`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Log Aggregation for Operators (Priority: P1)
+
+As an operator running FinFocus plugins, I want all plugin logs in JSON format so that my log aggregator (ELK, Splunk, Datadog) can parse and index them automatically.
+
+**Why this priority**: JSON logging is the core deliverable - without it, the entire feature fails to meet its primary purpose.
+
+**Independent Test**: Can be fully tested by running the plugin and capturing stderr output, then validating it parses as valid JSON with expected fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin is running, **When** it emits a log message, **Then** the output is valid JSON with `level`, `message`, and `time` fields
+2. **Given** the plugin is running, **When** multiple log messages are emitted, **Then** each message appears on a separate line (newline-delimited JSON)
+3. **Given** the plugin is running, **When** it logs, **Then** all output goes to stderr (stdout remains clean for port discovery)
+
+---
+
+### User Story 2 - Debug Mode for Developers (Priority: P2)
+
+As a developer debugging plugin issues, I want to set `FINFOCUS_LOG_LEVEL=debug` to see verbose output including internal state and detailed error context.
+
+**Why this priority**: Debug capability is essential for troubleshooting but only needed during development/investigation, not normal operation.
+
+**Independent Test**: Can be fully tested by setting the environment variable and verifying debug-level messages appear that would not appear at default (info) level.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FINFOCUS_LOG_LEVEL=debug` is set, **When** the plugin starts, **Then** debug-level messages appear in stderr
+2. **Given** `FINFOCUS_LOG_LEVEL=error` is set, **When** the plugin runs normally, **Then** info and debug messages are suppressed
+3. **Given** no log level environment variable is set, **When** the plugin runs, **Then** the default level is `info`
+
+---
+
+### User Story 3 - Stdout/Stderr Separation for FinFocus Core (Priority: P1)
+
+As FinFocus Core, I need plugin logs completely isolated from stdout so that port discovery (the only stdout output) works reliably.
+
+**Why this priority**: This is a critical architectural constraint - mixing logs with port discovery breaks the plugin contract.
+
+**Independent Test**: Can be fully tested by capturing stdout and stderr separately, verifying stdout contains only `PORT=XXXX` and stderr contains all log output.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin starts successfully, **When** I capture stdout, **Then** it contains only `PORT=XXXX` format output
+2. **Given** the plugin logs at any level, **When** I capture stderr, **Then** all log messages appear there
+3. **Given** the plugin encounters an error, **When** it logs the error, **Then** the error appears on stderr (not stdout)
+
+---
+
+### User Story 4 - Structured Fields for Monitoring (Priority: P2)
+
+As a monitoring system, I want consistent structured fields (plugin name, version) in every log entry so I can filter and search logs across multiple plugins.
+
+**Why this priority**: Structured fields enable observability but the logging system works without them - they enhance rather than enable functionality.
+
+**Independent Test**: Can be fully tested by parsing any log entry and verifying the `plugin` and `version` fields are present with correct values.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin emits any log message, **When** I parse the JSON, **Then** the `plugin` field equals `azure-public`
+2. **Given** the plugin emits any log message, **When** I parse the JSON, **Then** the `version` field contains the build version (e.g., `1.0.0`)
+3. **Given** the plugin logs from different components, **When** I filter by `plugin` field, **Then** all azure-public logs are captured
+
+---
+
+### User Story 5 - Trace ID Propagation for Distributed Tracing (Priority: P1)
+
+As an operator debugging distributed systems, I want trace IDs from incoming requests to appear in all related log entries so I can correlate logs across FinFocus Core and all plugins.
+
+**Why this priority**: Trace ID propagation is essential for debugging in distributed systems - without it, correlating logs across service boundaries is nearly impossible.
+
+**Independent Test**: Can be fully tested by sending an RPC request with a trace ID in the context/metadata and verifying all resulting log entries include that trace ID.
+
+**Acceptance Scenarios**:
+
+1. **Given** an RPC request arrives with a trace ID in metadata, **When** the plugin logs during request processing, **Then** all log entries include the `trace_id` field with the incoming value
+2. **Given** an RPC request arrives without a trace ID, **When** the plugin logs during request processing, **Then** log entries omit the `trace_id` field (no empty or placeholder values)
+3. **Given** multiple concurrent requests with different trace IDs, **When** I filter logs by `trace_id`, **Then** each trace ID shows only logs from its specific request
+
+---
+
+### Edge Cases
+
+- What happens when `FINFOCUS_LOG_LEVEL` is set to an invalid value (e.g., "verbose", "3", "")?
+  - System falls back to `info` level and logs a warning about the invalid value
+- What happens when both `FINFOCUS_LOG_LEVEL` and `LOG_LEVEL` are set?
+  - `FINFOCUS_LOG_LEVEL` takes precedence
+- What happens when log messages contain special characters (newlines, quotes, unicode)?
+  - JSON encoding handles escaping automatically via zerolog; message integrity is preserved (no explicit test required - zerolog library behavior)
+- What happens when a trace ID is malformed or excessively long?
+  - System accepts and logs the trace ID as-is (validation is caller's responsibility)
+- What happens when trace ID is passed but logger context is lost mid-request?
+  - Logger with trace ID context must be passed through all function calls in request path
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST initialize logger via `pluginsdk.NewPluginLogger("azure-public", version, level, nil)`
+- **FR-002**: System MUST write all log output to stderr, never to stdout
+- **FR-003**: System MUST format logs as JSON with one complete object per line (newline-delimited JSON)
+- **FR-004**: System MUST include `level`, `message`, and `time` fields in every log entry
+- **FR-005**: System MUST include `plugin: "azure-public"` field in every log entry
+- **FR-006**: System MUST include `version` field with the current build version in every log entry
+- **FR-007**: System MUST read log level from `FINFOCUS_LOG_LEVEL` environment variable using `pluginsdk.GetLogLevel()`
+- **FR-008**: System MUST fall back to `LOG_LEVEL` environment variable if `FINFOCUS_LOG_LEVEL` is not set
+- **FR-009**: System MUST default to `info` level if no log level environment variable is set
+- **FR-010**: System MUST pass the initialized logger to the plugin constructor for use in RPC handlers
+- **FR-011**: System MUST support standard log levels: trace, debug, info, warn, error, fatal, panic
+- **FR-012**: System MUST extract trace ID from request context using `pluginsdk.TraceIDFromContext(ctx)` (SDK handles gRPC metadata key `x-finfocus-trace-id`)
+- **FR-013**: System MUST include `trace_id` field in all log entries when a trace ID is present in the request context
+- **FR-014**: System MUST propagate the logger with trace ID context through all function calls within a request
+- **FR-015**: System MUST omit `trace_id` field from log entries when no trace ID is present (no empty or null values)
+
+### Key Entities
+
+- **Logger**: Zerolog logger instance configured with plugin metadata and stderr output
+- **Log Entry**: JSON object containing level, message, time, plugin, version, trace_id (when present), and optional context fields
+- **Log Level**: Enumeration controlling message visibility (trace < debug < info < warn < error < fatal < panic)
+- **Trace ID**: Unique identifier passed via gRPC metadata that correlates all logs from a single request across service boundaries
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of log messages parse as valid JSON
+- **SC-002**: 0% of log messages appear on stdout (all on stderr)
+- **SC-003**: 100% of log entries contain required fields (level, message, time, plugin, version)
+- **SC-004**: Setting `FINFOCUS_LOG_LEVEL=error` suppresses all info-level messages
+- **SC-005**: Setting `FINFOCUS_LOG_LEVEL=debug` enables debug-level messages
+- **SC-006**: Log aggregators can parse plugin logs without custom parsing rules
+- **SC-007**: 100% of logs emitted during a traced request include the correct `trace_id` field
+- **SC-008**: Filtering logs by `trace_id` returns all and only logs from that specific request
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations (≥80% for business logic)
+- [x] Error handling strategy is defined (invalid log levels fall back to info with warning)
+- [x] Code complexity is considered (logger initialization is straightforward single function)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then format)
+- [x] Integration test needs identified (run binary and parse stderr JSON output)
+- [x] Performance test criteria specified (N/A - logging overhead is negligible)
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable (invalid log level warning includes valid options)
+- [x] Response time expectations defined (N/A - logging is synchronous and fast)
+- [x] Observability requirements specified (this feature IS the observability implementation)
+
+### Documentation
+
+- [x] README.md updates identified (document FINFOCUS_LOG_LEVEL environment variable)
+- [x] API documentation needs outlined (godoc for any exported logger helpers)
+- [x] Examples/quickstart guide planned (example log output format in README)
+
+### Performance & Reliability
+
+- [x] Performance targets specified (logging adds <1ms p99 overhead per call)
+- [x] Reliability requirements defined (logger initialization cannot fail - falls back to defaults)
+- [x] Resource constraints considered (zerolog is zero-allocation in hot paths)
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The `pluginsdk.NewPluginLogger` and `pluginsdk.GetLogLevel` functions exist and work as documented
+- The plugin version is available at initialization time (injected at build time via ldflags)
+- Zerolog's default JSON formatting meets the requirements (no custom formatting needed)
+- The existing `main.go` structure allows logger injection into the plugin constructor
+- FinFocus Core passes trace IDs via gRPC metadata using key `x-finfocus-trace-id`
+- The pluginsdk provides utilities for extracting trace ID from gRPC context/metadata

--- a/specs/003-zerolog-logging/tasks.md
+++ b/specs/003-zerolog-logging/tasks.md
@@ -1,0 +1,272 @@
+# Tasks: Implement Zerolog Structured Logging
+
+**Input**: Design documents from `/specs/003-zerolog-logging/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Required per constitution (TDD workflow - tests before implementation)
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1-US5)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md structure:
+
+```text
+cmd/finfocus-plugin-azure-public/
+├── main.go              # Entry point with logger initialization
+└── main_test.go         # Main tests
+
+internal/
+├── logging/             # NEW: Plugin-specific logger utilities (wraps SDK)
+│   ├── request.go       # RequestLogger helper using pluginsdk.TraceIDFromContext
+│   └── request_test.go  # Unit tests for request logger helper
+└── pricing/
+    ├── calculator.go    # RPC handler with logger
+    └── calculator_test.go
+```
+
+## SDK Functions Used (DO NOT REIMPLEMENT)
+
+From `finfocus-spec/sdk/go/pluginsdk/logging.go`:
+
+- `pluginsdk.TraceIDMetadataKey` - constant: `x-finfocus-trace-id`
+- `pluginsdk.TraceIDFromContext(ctx)` - extract trace ID from context
+- `pluginsdk.ContextWithTraceID(ctx, traceID)` - store trace ID in context
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create new package structure for logging utilities
+
+- [x] T001 Create internal/logging/ directory structure
+- [x] T002 [P] Verify finfocus-spec dependency has logging utilities in go.mod
+
+---
+
+## Phase 2: Foundational (RequestLogger Helper)
+
+**Purpose**: Plugin-specific helper that wraps SDK functions for consistent usage
+
+**Note**: Uses `pluginsdk.TraceIDFromContext` - does NOT reimplement extraction
+
+### Tests First (TDD)
+
+- [x] T003 [P] Write unit tests for RequestLogger in internal/logging/request_test.go
+  - Test: Returns logger with trace_id field when trace ID in context
+  - Test: Returns base logger unchanged when no trace ID in context
+  - Test: Preserves all existing logger fields (plugin, version)
+  - Test: Does not add empty trace_id field when trace ID is empty string
+
+### Implementation
+
+- [x] T004 Implement RequestLogger function in internal/logging/request.go
+- [x] T005 Add godoc comment explaining RequestLogger wraps pluginsdk.TraceIDFromContext
+- [x] T006 Run tests to verify T003 passes: `go test ./internal/logging/...`
+
+**Checkpoint**: RequestLogger helper ready for use in RPC handlers
+
+---
+
+## Phase 3: User Story 1+3+4 - JSON Logging with Structured Fields (Priority: P1)
+
+**Goal**: All logs output as valid JSON to stderr with plugin, version fields
+
+**Independent Test**: Run plugin, capture stderr, validate JSON with jq
+
+**Note**: US1 (JSON format), US3 (stderr only), US4 (structured fields) are satisfied by existing pluginsdk.NewPluginLogger. This phase verifies and documents.
+
+### Tests First (TDD)
+
+- [x] T007 [P] [US1] Write test in cmd/finfocus-plugin-azure-public/main_test.go
+  - Test: Verify log output is valid JSON
+  - Test: Verify log contains level, message, time fields
+  - Test: Verify log contains plugin_name="azure-public" field
+  - Test: Verify log contains plugin_version field
+
+- [x] T008 [P] [US3] Write test in cmd/finfocus-plugin-azure-public/main_test.go
+  - Test: Verify all log output goes to stderr
+  - Test: Verify stdout contains only PORT=XXXXX format
+
+### Implementation
+
+- [x] T009 [US1] Verify pluginsdk.NewPluginLogger outputs JSON format (existing code)
+- [x] T010 [US3] Verify logger writes to stderr only (existing code)
+- [x] T011 [US4] Verify logger includes plugin_name and plugin_version fields (existing code)
+- [x] T012 Run tests to verify T007, T008 pass: `go test ./cmd/...`
+
+**Checkpoint**: Basic JSON logging to stderr verified and tested
+
+---
+
+## Phase 4: User Story 2 - Debug Mode (Priority: P2)
+
+**Goal**: Log level controllable via FINFOCUS_LOG_LEVEL environment variable
+
+**Independent Test**: Set env var, verify debug logs appear/suppressed
+
+**Note**: Already implemented in main.go using pluginsdk.GetLogLevel(). This phase adds tests.
+
+### Tests First (TDD)
+
+- [x] T013 [P] [US2] Write test in cmd/finfocus-plugin-azure-public/main_test.go
+  - Test: FINFOCUS_LOG_LEVEL=debug shows debug messages
+  - Test: FINFOCUS_LOG_LEVEL=error suppresses info messages
+  - Test: Default level is info when no env var set
+  - Test: FINFOCUS_LOG_LEVEL takes precedence over LOG_LEVEL
+  - Test: Invalid FINFOCUS_LOG_LEVEL logs warning and falls back to info
+
+### Implementation
+
+- [x] T014 [US2] Verify existing log level parsing in main.go handles all cases
+- [x] T015 [US2] Add warning log for invalid log level values (fallback to info)
+- [x] T016 Run tests to verify T013 passes: `go test ./cmd/...`
+
+**Checkpoint**: Log level control verified and tested
+
+---
+
+## Phase 5: User Story 5 - Trace ID Propagation (Priority: P1)
+
+**Goal**: Trace IDs from gRPC metadata appear in all request logs
+
+**Independent Test**: Send RPC with x-finfocus-trace-id, verify logs contain trace_id field
+
+### Tests First (TDD)
+
+- [x] T017 [P] [US5] Write test in internal/pricing/calculator_test.go
+  - Test: Log includes trace_id when present in context (via pluginsdk.ContextWithTraceID)
+  - Test: Log omits trace_id field when not in context (no empty string)
+  - Test: Multiple concurrent requests maintain separate trace IDs
+
+### Implementation
+
+- [x] T018 [US5] Modify Calculator struct in internal/pricing/calculator.go to accept logger
+- [x] T019 [US5] Update NewCalculator constructor to take zerolog.Logger parameter
+- [x] T020 [US5] Modify main.go to pass logger to NewCalculator
+- [x] T021 [US5] Use logging.RequestLogger in GetPluginInfo handler
+- [x] T022 [US5] Use logging.RequestLogger in EstimateCost handler
+- [x] T023 [US5] Add import for internal/logging package in calculator.go
+- [x] T024 Run tests to verify T017 passes: `go test ./internal/pricing/...`
+
+**Checkpoint**: Trace ID propagation complete - all P1 stories done
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation, and quality checks
+
+### Constitution Compliance Tasks
+
+- [x] T025 [P] Run `make lint` and fix all linting issues
+- [x] T026 [P] Run `go test -race ./...` to verify thread safety
+- [x] T027 [P] Verify test coverage ≥80% for internal/logging: `go test -cover ./internal/logging/...`
+- [x] T028 [P] Verify godoc comments on RequestLogger function
+- [x] T029 [P] Update README.md with FINFOCUS_LOG_LEVEL documentation
+- [x] T030 [P] Update README.md with log format examples (from quickstart.md)
+
+### Final Validation
+
+- [x] T031 Run full test suite: `make test`
+- [x] T032 Run integration test: start plugin, parse stderr with jq
+- [x] T033 Verify quickstart.md examples work as documented
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```text
+Phase 1: Setup ──────────────────────────────► (no dependencies)
+                    │
+                    ▼
+Phase 2: Foundational (RequestLogger) ───────► (depends on Phase 1)
+                    │
+          ┌────────┼────────┬────────┐
+          ▼        ▼        ▼        ▼
+Phase 3: US1+3+4  Phase 4: US2   Phase 5: US5  (all depend on Phase 2)
+(JSON/stderr)     (Log Level)   (Trace ID)
+          │        │             │
+          └────────┴─────────────┘
+                    │
+                    ▼
+Phase 6: Polish ─────────────────────────────► (depends on all stories)
+```
+
+### User Story Independence
+
+- **US1+3+4 (JSON/stderr)**: Can start after Phase 2 - No dependencies on US2 or US5
+- **US2 (Log Level)**: Can start after Phase 2 - No dependencies on other stories
+- **US5 (Trace ID)**: Can start after Phase 2 - Uses RequestLogger helper
+
+### Parallel Opportunities Within Phases
+
+**Phase 2 (Foundational)**:
+
+```bash
+# Tests can be written in parallel:
+T003 [P] Write unit tests for RequestLogger
+```
+
+**Phase 3-5 (User Stories)**:
+
+```bash
+# All user story test tasks marked [P] can run in parallel:
+T007 [P] [US1] Write JSON format tests
+T008 [P] [US3] Write stderr tests
+T013 [P] [US2] Write log level tests
+T017 [P] [US5] Write trace ID propagation tests
+```
+
+**Phase 6 (Polish)**:
+
+```bash
+# All polish tasks marked [P] can run in parallel:
+T025-T030 can all run concurrently
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (P1 Stories Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T006)
+3. Complete Phase 3: US1+3+4 JSON/stderr (T007-T012)
+4. Complete Phase 5: US5 Trace ID (T017-T024)
+5. **STOP and VALIDATE**: All P1 stories complete and tested
+6. Run `make lint && make test` to verify
+
+### Full Implementation
+
+1. Continue with Phase 4: US2 Log Level (T013-T016)
+2. Complete Phase 6: Polish (T025-T033)
+3. Final validation with full test suite
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+- **Developer A**: Phase 2 (Foundational) → Phase 5 (US5 Trace ID)
+- **Developer B**: Phase 3 (US1+3+4) → Phase 4 (US2) → Phase 6 (Polish)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- TDD required: Write tests FIRST, verify they FAIL, then implement
+- **SDK reuse**: Use `pluginsdk.TraceIDFromContext` - do NOT reimplement
+- `internal/logging` provides thin wrapper for plugin-specific patterns
+- Constitution requires ≥80% test coverage for business logic
+- All logs MUST go to stderr - stdout is reserved for PORT=XXXXX only


### PR DESCRIPTION
## Summary

- Add JSON-formatted structured logging to stderr with plugin_name, plugin_version, time, level, and message fields
- Implement trace ID propagation from gRPC metadata for distributed tracing via new `internal/logging` package wrapping pluginsdk utilities
- Add FINFOCUS_LOG_LEVEL environment variable support with fallback to LOG_LEVEL, defaulting to info level
- Log warning with error details when invalid log level is configured
- Add DoS protection by truncating trace IDs longer than 128 characters
- Comprehensive test coverage: 100% for logging package, integration tests for log level control and JSON output validation

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes with all tests green
- [x] `go test -race ./...` passes with no race conditions
- [x] `go test -cover ./internal/logging/...` shows 100% coverage
- [x] Integration tests verify JSON log format and stderr output
- [x] Log level tests verify debug/info/error level filtering
- [x] Trace ID propagation verified via unit tests

## Changes

### New files

- `internal/logging/request.go` - RequestLogger helper that extracts trace IDs from context and creates request-scoped loggers with trace_id field
- `internal/logging/request_test.go` - Unit tests for RequestLogger including trace ID extraction, preservation of existing fields, and truncation

### Modified files

- `cmd/finfocus-plugin-azure-public/main.go` - Add warning log for invalid log level with error details, wrap port parsing errors properly, pass logger to Calculator constructor
- `cmd/finfocus-plugin-azure-public/main_test.go` - Add integration tests for log format validation, log level control, and structured field presence
- `internal/pricing/calculator.go` - Accept logger via constructor, use RequestLogger in GetPluginInfo and EstimateCost handlers
- `internal/pricing/calculator_test.go` - Add trace ID propagation tests including concurrent request isolation test
- `README.md` - Document log format, FINFOCUS_LOG_LEVEL, and jq examples
- `CLAUDE.md` - Add zerolog SDK constants documentation
- `ROADMAP.md` - Update progress tracking

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured JSON logs to stderr including level, plugin, version, time, and optional trace_id; configurable log level via FINFOCUS_LOG_LEVEL (takes precedence over LOG_LEVEL).
  * Per-request trace ID propagation for improved observability.

* **Documentation**
  * Extensive logging spec, quickstart, examples, parsing tips (jq), and updated README and roadmap.

* **Tests**
  * New tests validating JSON log schema, timestamps, log-level behavior, trace_id propagation, and startup/shutdown/port handling.

* **Bug Fixes**
  * Invalid log levels now emit a warning and fall back to info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->