### PR TITLE
feat(azureclient): add Azure Retail Prices API data models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@
 - N/A (CI workflow - no persistent storage) (005-ci-pipeline)
 - Go 1.25.5 + `github.com/hashicorp/go-retryablehttp` (HTTP client with retry), `github.com/rs/zerolog` (structured logging) (006-http-client-retry)
 - N/A - stateless plugin (in-memory only) (006-http-client-retry)
+- Go 1.25.5 + `encoding/json` (stdlib), `github.com/rs/zerolog` (logging) (007-azure-price-models)
 
 ## Recent Changes
 - 002-grpc-server-port: Added Go 1.25.5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ To provide accurate, real-time Azure cost estimates for FinFocus by querying the
 
 **Issues:**
 
-- [#7](https://github.com/rshade/finfocus-plugin-azure-public/issues/7) Implement HTTP client with retry logic for Azure Retail Prices API
+- [x] [#7](https://github.com/rshade/finfocus-plugin-azure-public/issues/7) Implement HTTP client with retry logic for Azure Retail Prices API
 - [#8](https://github.com/rshade/finfocus-plugin-azure-public/issues/8) Define Azure Retail Prices API data models
 - [#9](https://github.com/rshade/finfocus-plugin-azure-public/issues/9) Implement OData filter query builder
 - [#10](https://github.com/rshade/finfocus-plugin-azure-public/issues/10) Implement pagination handler for Azure API responses
@@ -184,10 +184,10 @@ The following features violate architectural constraints and are not planned:
 | Milestone                             | Status      | Progress    |
 | ------------------------------------- | ----------- | ----------- |
 | v0.1.0 - Scaffold & Transport         | ✅ Complete  | 6/6 (100%)  |
-| v0.2.0 - Azure Client                 | ⚪ Not Started | 0/5 (0%)    |
+| v0.2.0 - Azure Client                 | 🔵 Active    | 1/5 (20%)   |
 | v0.3.0 - Caching Layer                | ⚪ Not Started | 0/4 (0%)    |
 | v0.4.0 - Field Mapping & Estimation   | ⚪ Not Started | 0/5 (0%)    |
 
-**Completed Issues**: #1, #2, #3, #4, #5, #6
+**Completed Issues**: #1, #2, #3, #4, #5, #6, #7
 
 **Total Core Roadmap**: 20 issues across 4 phases (6 completed)

--- a/internal/azureclient/client.go
+++ b/internal/azureclient/client.go
@@ -158,7 +158,7 @@ func (c *Client) fetchPage(ctx context.Context, requestURL string) ([]PriceItem,
 	}
 
 	// Parse response
-	var priceResp priceResponse
+	var priceResp PriceResponse
 	if decodeErr := json.NewDecoder(resp.Body).Decode(&priceResp); decodeErr != nil {
 		return nil, "", fmt.Errorf("%w: %w", ErrInvalidResponse, decodeErr)
 	}

--- a/internal/azureclient/client_test.go
+++ b/internal/azureclient/client_test.go
@@ -72,7 +72,7 @@ func TestNewClient_InvalidConfig(t *testing.T) {
 
 func TestClient_GetPrices_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := priceResponse{
+		resp := PriceResponse{
 			BillingCurrency: "USD",
 			Items: []PriceItem{
 				{
@@ -118,12 +118,12 @@ func TestClient_GetPrices_Pagination(t *testing.T) {
 	callCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		var resp priceResponse
+		var resp PriceResponse
 
 		if callCount == 1 {
 			// httptest server URL is available via server.URL in the outer scope
 			// For the handler, we construct the next page link using http scheme
-			resp = priceResponse{
+			resp = PriceResponse{
 				BillingCurrency: "USD",
 				Items: []PriceItem{
 					{ArmSkuName: "SKU1", RetailPrice: 0.01},
@@ -132,7 +132,7 @@ func TestClient_GetPrices_Pagination(t *testing.T) {
 				Count:        1,
 			}
 		} else {
-			resp = priceResponse{
+			resp = PriceResponse{
 				BillingCurrency: "USD",
 				Items: []PriceItem{
 					{ArmSkuName: "SKU2", RetailPrice: 0.02},
@@ -177,7 +177,7 @@ func TestClient_GetPrices_Retry429(t *testing.T) {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
-		resp := priceResponse{Items: []PriceItem{{ArmSkuName: "Test"}}, Count: 1}
+		resp := PriceResponse{Items: []PriceItem{{ArmSkuName: "Test"}}, Count: 1}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Logf("error encoding response: %v", err)
@@ -215,7 +215,7 @@ func TestClient_GetPrices_Retry503(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		resp := priceResponse{Items: []PriceItem{{ArmSkuName: "Test"}}, Count: 1}
+		resp := PriceResponse{Items: []PriceItem{{ArmSkuName: "Test"}}, Count: 1}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Logf("error encoding response: %v", err)
@@ -323,7 +323,7 @@ func TestClient_GetPrices_UserAgent(t *testing.T) {
 	var receivedUA string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUA = r.Header.Get("User-Agent")
-		resp := priceResponse{Items: []PriceItem{}, Count: 0}
+		resp := PriceResponse{Items: []PriceItem{}, Count: 0}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Logf("error encoding response: %v", err)
@@ -357,7 +357,7 @@ func TestClient_GetPrices_Logging(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		resp := priceResponse{Items: []PriceItem{}, Count: 0}
+		resp := PriceResponse{Items: []PriceItem{}, Count: 0}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Logf("error encoding response: %v", err)
@@ -562,7 +562,7 @@ func TestClient_Close(t *testing.T) {
 func TestClient_GetPrices_Concurrent(t *testing.T) {
 	// Test that concurrent requests work correctly
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := priceResponse{
+		resp := PriceResponse{
 			Items: []PriceItem{{ArmSkuName: "Test", RetailPrice: 0.01}},
 			Count: 1,
 		}

--- a/internal/azureclient/types.go
+++ b/internal/azureclient/types.go
@@ -90,36 +90,141 @@ type PriceQuery struct {
 	CurrencyCode string
 }
 
-// PriceItem represents a single price entry from the Azure API.
-// Field names match Azure API JSON field names (using json tags).
+// PriceItem represents a single price entry from the Azure Retail Prices API.
+// Each item corresponds to a specific SKU/meter combination in a region.
+//
+// Field names match Azure API JSON field names using json struct tags.
+// All fields use Go types appropriate for their JSON counterparts.
+//
+// Example JSON:
+//
+//	{
+//	  "currencyCode": "USD",
+//	  "retailPrice": 0.0104,
+//	  "armRegionName": "eastus",
+//	  "skuName": "B1s",
+//	  "serviceName": "Virtual Machines",
+//	  "type": "Consumption"
+//	}
 type PriceItem struct {
-	ArmRegionName        string  `json:"armRegionName"`
-	ArmSkuName           string  `json:"armSkuName"`
-	CurrencyCode         string  `json:"currencyCode"`
-	EffectiveStartDate   string  `json:"effectiveStartDate"`
-	IsPrimaryMeterRegion bool    `json:"isPrimaryMeterRegion"`
-	MeterID              string  `json:"meterId"`
-	MeterName            string  `json:"meterName"`
-	ProductID            string  `json:"productId"`
-	ProductName          string  `json:"productName"`
-	RetailPrice          float64 `json:"retailPrice"`
-	ServiceFamily        string  `json:"serviceFamily"`
-	ServiceID            string  `json:"serviceId"`
-	ServiceName          string  `json:"serviceName"`
-	SkuID                string  `json:"skuId"`
-	SkuName              string  `json:"skuName"`
-	TierMinimumUnits     float64 `json:"tierMinimumUnits"`
-	Type                 string  `json:"type"`
-	UnitOfMeasure        string  `json:"unitOfMeasure"`
-	UnitPrice            float64 `json:"unitPrice"`
+	// ArmRegionName is the Azure Resource Manager region identifier (e.g., "eastus").
+	// This is the programmatic region name used in ARM templates.
+	ArmRegionName string `json:"armRegionName"`
+
+	// ArmSkuName is the SKU identifier used in Azure Resource Manager (e.g., "Standard_B1s").
+	// This is the value used when provisioning resources via ARM.
+	ArmSkuName string `json:"armSkuName"`
+
+	// AvailabilityID is the availability identifier.
+	// Often empty or null in API responses.
+	AvailabilityID string `json:"availabilityId,omitempty"`
+
+	// CurrencyCode is the ISO 4217 currency code for the price (e.g., "USD").
+	CurrencyCode string `json:"currencyCode"`
+
+	// EffectiveStartDate is when this price became effective (ISO 8601 format).
+	// Example: "2020-08-01T00:00:00Z"
+	EffectiveStartDate string `json:"effectiveStartDate"`
+
+	// IsPrimaryMeterRegion indicates whether this is the primary region for the meter.
+	// When true, this region is used for billing purposes.
+	IsPrimaryMeterRegion bool `json:"isPrimaryMeterRegion"`
+
+	// Location is the human-readable Azure datacenter location (e.g., "US East").
+	// This is the display name shown in the Azure portal.
+	Location string `json:"location,omitempty"`
+
+	// MeterID is the unique identifier for the billing meter (UUID format).
+	// This is used in Azure cost management and billing.
+	MeterID string `json:"meterId"`
+
+	// MeterName is the human-readable name for the meter (e.g., "B1s").
+	MeterName string `json:"meterName"`
+
+	// ProductID is the unique identifier for the product.
+	ProductID string `json:"productId"`
+
+	// ProductName is the full product name (e.g., "Virtual Machines BS Series").
+	ProductName string `json:"productName"`
+
+	// ReservationTerm is the commitment period for reservation pricing.
+	// Only present when Type is "Reservation".
+	// Values: "1 Year", "3 Years"
+	ReservationTerm string `json:"reservationTerm,omitempty"`
+
+	// RetailPrice is the Microsoft retail price without any discount.
+	// This is the list price for the resource.
+	RetailPrice float64 `json:"retailPrice"`
+
+	// ServiceFamily is the service category (e.g., "Compute", "Storage", "Networking").
+	ServiceFamily string `json:"serviceFamily"`
+
+	// ServiceID is the unique identifier for the Azure service.
+	ServiceID string `json:"serviceId"`
+
+	// ServiceName is the name of the Azure service (e.g., "Virtual Machines").
+	ServiceName string `json:"serviceName"`
+
+	// SkuID is the unique identifier for this SKU (e.g., "DZH318Z0BQPS/00TG").
+	SkuID string `json:"skuId"`
+
+	// SkuName is the display name for the SKU (e.g., "B1s").
+	// This is a human-friendly version of the SKU identifier.
+	SkuName string `json:"skuName"`
+
+	// TierMinimumUnits is the minimum units of consumption for this price tier.
+	// Value is 0 for non-tiered pricing.
+	TierMinimumUnits float64 `json:"tierMinimumUnits"`
+
+	// Type indicates the pricing model for this item.
+	// Values: "Consumption", "Reservation", "DevTestConsumption"
+	Type string `json:"type"`
+
+	// UnitOfMeasure describes the billing unit (e.g., "1 Hour", "1 GB", "10K Transactions").
+	UnitOfMeasure string `json:"unitOfMeasure"`
+
+	// UnitPrice is the price per unit of measure.
+	// For most resources, this equals RetailPrice.
+	UnitPrice float64 `json:"unitPrice"`
 }
 
-// priceResponse is the internal response envelope from Azure API.
-type priceResponse struct {
-	BillingCurrency    string      `json:"BillingCurrency"`
-	CustomerEntityID   string      `json:"CustomerEntityId"`
-	CustomerEntityType string      `json:"CustomerEntityType"`
-	Items              []PriceItem `json:"Items"`
-	NextPageLink       string      `json:"NextPageLink"`
-	Count              int         `json:"Count"`
+// PriceResponse represents the envelope returned by the Azure Retail Prices API.
+// It contains a paginated list of price items along with metadata.
+//
+// The API returns up to 1000 items per request. When NextPageLink is non-empty,
+// additional pages are available.
+//
+// Example response:
+//
+//	{
+//	  "BillingCurrency": "USD",
+//	  "CustomerEntityId": "Default",
+//	  "CustomerEntityType": "Retail",
+//	  "Items": [...],
+//	  "NextPageLink": "https://prices.azure.com/api/retail/prices?$skip=1000",
+//	  "Count": 1000
+//	}
+type PriceResponse struct {
+	// BillingCurrency is the currency code for all prices in the response.
+	// Typically "USD" unless a different currency was requested.
+	BillingCurrency string `json:"BillingCurrency"`
+
+	// CustomerEntityID identifies the customer entity for pricing.
+	// Default value is "Default" for retail pricing.
+	CustomerEntityID string `json:"CustomerEntityId"`
+
+	// CustomerEntityType indicates the type of pricing returned.
+	// Value is "Retail" for the public retail prices API.
+	CustomerEntityType string `json:"CustomerEntityType"`
+
+	// Items contains the price entries for this page of results.
+	// Maximum 1000 items per response.
+	Items []PriceItem `json:"Items"`
+
+	// NextPageLink is the URL to fetch the next page of results.
+	// Empty string indicates no more pages are available.
+	NextPageLink string `json:"NextPageLink"`
+
+	// Count is the number of items in this page of results.
+	Count int `json:"Count"`
 }

--- a/internal/azureclient/types_test.go
+++ b/internal/azureclient/types_test.go
@@ -1,0 +1,549 @@
+package azureclient
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Sample JSON from Azure Retail Prices API for testing.
+// See research.md for field documentation.
+
+const samplePriceItemJSON = `{
+  "currencyCode": "USD",
+  "tierMinimumUnits": 0.0,
+  "retailPrice": 0.0104,
+  "unitPrice": 0.0104,
+  "armRegionName": "eastus",
+  "location": "US East",
+  "effectiveStartDate": "2020-08-01T00:00:00Z",
+  "meterId": "000a794b-bdb0-58be-a0cd-0c3a0f222923",
+  "meterName": "B1s",
+  "productId": "DZH318Z0BQPS",
+  "skuId": "DZH318Z0BQPS/00TG",
+  "availabilityId": null,
+  "productName": "Virtual Machines BS Series",
+  "skuName": "B1s",
+  "serviceName": "Virtual Machines",
+  "serviceId": "DZH313Z7MMC8",
+  "serviceFamily": "Compute",
+  "unitOfMeasure": "1 Hour",
+  "type": "Consumption",
+  "isPrimaryMeterRegion": true,
+  "armSkuName": "Standard_B1s"
+}`
+
+const sampleReservationPriceItemJSON = `{
+  "currencyCode": "USD",
+  "tierMinimumUnits": 0.0,
+  "retailPrice": 3285.0,
+  "unitPrice": 3285.0,
+  "armRegionName": "eastus",
+  "location": "US East",
+  "effectiveStartDate": "2023-01-01T00:00:00Z",
+  "meterId": "abc123-reservation-meter",
+  "meterName": "D2s v3 Reserved",
+  "productId": "DZH318Z0BQPS",
+  "skuId": "DZH318Z0BQPS/RESV",
+  "productName": "Virtual Machines Dv3 Series",
+  "skuName": "D2s v3",
+  "serviceName": "Virtual Machines",
+  "serviceId": "DZH313Z7MMC8",
+  "serviceFamily": "Compute",
+  "unitOfMeasure": "1 Year",
+  "type": "Reservation",
+  "reservationTerm": "1 Year",
+  "isPrimaryMeterRegion": true,
+  "armSkuName": "Standard_D2s_v3"
+}`
+
+const samplePriceResponseJSON = `{
+  "BillingCurrency": "USD",
+  "CustomerEntityId": "Default",
+  "CustomerEntityType": "Retail",
+  "Items": [
+    {
+      "currencyCode": "USD",
+      "retailPrice": 0.0104,
+      "armRegionName": "eastus",
+      "skuName": "B1s",
+      "type": "Consumption"
+    }
+  ],
+  "NextPageLink": "https://prices.azure.com/api/retail/prices?$skip=1000",
+  "Count": 1
+}`
+
+func TestPriceResponse_UnmarshalJSON(t *testing.T) {
+	var resp PriceResponse
+	if err := json.Unmarshal([]byte(samplePriceResponseJSON), &resp); err != nil {
+		t.Fatalf("failed to unmarshal PriceResponse: %v", err)
+	}
+
+	// Verify envelope fields
+	if resp.BillingCurrency != "USD" {
+		t.Errorf("expected BillingCurrency=USD, got %s", resp.BillingCurrency)
+	}
+	if resp.CustomerEntityID != "Default" {
+		t.Errorf("expected CustomerEntityID=Default, got %s", resp.CustomerEntityID)
+	}
+	if resp.CustomerEntityType != "Retail" {
+		t.Errorf("expected CustomerEntityType=Retail, got %s", resp.CustomerEntityType)
+	}
+	if resp.NextPageLink != "https://prices.azure.com/api/retail/prices?$skip=1000" {
+		t.Errorf("unexpected NextPageLink: %s", resp.NextPageLink)
+	}
+	if resp.Count != 1 {
+		t.Errorf("expected Count=1, got %d", resp.Count)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+
+	// Verify item in envelope
+	item := resp.Items[0]
+	if item.CurrencyCode != "USD" {
+		t.Errorf("expected item CurrencyCode=USD, got %s", item.CurrencyCode)
+	}
+	if item.RetailPrice != 0.0104 {
+		t.Errorf("expected item RetailPrice=0.0104, got %f", item.RetailPrice)
+	}
+}
+
+func TestPriceItem_UnmarshalJSON_AllFields(t *testing.T) {
+	var item PriceItem
+	if err := json.Unmarshal([]byte(samplePriceItemJSON), &item); err != nil {
+		t.Fatalf("failed to unmarshal PriceItem: %v", err)
+	}
+
+	// Pricing fields
+	if item.RetailPrice != 0.0104 {
+		t.Errorf("RetailPrice: expected 0.0104, got %f", item.RetailPrice)
+	}
+	if item.UnitPrice != 0.0104 {
+		t.Errorf("UnitPrice: expected 0.0104, got %f", item.UnitPrice)
+	}
+	if item.TierMinimumUnits != 0.0 {
+		t.Errorf("TierMinimumUnits: expected 0.0, got %f", item.TierMinimumUnits)
+	}
+	if item.CurrencyCode != "USD" {
+		t.Errorf("CurrencyCode: expected USD, got %s", item.CurrencyCode)
+	}
+
+	// Resource fields
+	if item.ArmRegionName != "eastus" {
+		t.Errorf("ArmRegionName: expected eastus, got %s", item.ArmRegionName)
+	}
+	if item.Location != "US East" {
+		t.Errorf("Location: expected 'US East', got %s", item.Location)
+	}
+	if item.ArmSkuName != "Standard_B1s" {
+		t.Errorf("ArmSkuName: expected Standard_B1s, got %s", item.ArmSkuName)
+	}
+	if item.SkuName != "B1s" {
+		t.Errorf("SkuName: expected B1s, got %s", item.SkuName)
+	}
+	if item.SkuID != "DZH318Z0BQPS/00TG" {
+		t.Errorf("SkuID: expected DZH318Z0BQPS/00TG, got %s", item.SkuID)
+	}
+
+	// Service fields
+	if item.ServiceName != "Virtual Machines" {
+		t.Errorf("ServiceName: expected 'Virtual Machines', got %s", item.ServiceName)
+	}
+	if item.ServiceID != "DZH313Z7MMC8" {
+		t.Errorf("ServiceID: expected DZH313Z7MMC8, got %s", item.ServiceID)
+	}
+	if item.ServiceFamily != "Compute" {
+		t.Errorf("ServiceFamily: expected Compute, got %s", item.ServiceFamily)
+	}
+	if item.ProductName != "Virtual Machines BS Series" {
+		t.Errorf("ProductName: expected 'Virtual Machines BS Series', got %s", item.ProductName)
+	}
+	if item.ProductID != "DZH318Z0BQPS" {
+		t.Errorf("ProductID: expected DZH318Z0BQPS, got %s", item.ProductID)
+	}
+
+	// Meter fields
+	if item.MeterID != "000a794b-bdb0-58be-a0cd-0c3a0f222923" {
+		t.Errorf("MeterID: expected 000a794b-bdb0-58be-a0cd-0c3a0f222923, got %s", item.MeterID)
+	}
+	if item.MeterName != "B1s" {
+		t.Errorf("MeterName: expected B1s, got %s", item.MeterName)
+	}
+	if item.UnitOfMeasure != "1 Hour" {
+		t.Errorf("UnitOfMeasure: expected '1 Hour', got %s", item.UnitOfMeasure)
+	}
+	if !item.IsPrimaryMeterRegion {
+		t.Error("IsPrimaryMeterRegion: expected true")
+	}
+
+	// Temporal fields
+	if item.EffectiveStartDate != "2020-08-01T00:00:00Z" {
+		t.Errorf("EffectiveStartDate: expected 2020-08-01T00:00:00Z, got %s", item.EffectiveStartDate)
+	}
+
+	// Type fields
+	if item.Type != "Consumption" {
+		t.Errorf("Type: expected Consumption, got %s", item.Type)
+	}
+
+	// Optional fields - availabilityId is null in sample, should be empty string
+	if item.AvailabilityID != "" {
+		t.Errorf("AvailabilityID: expected empty string for null, got %s", item.AvailabilityID)
+	}
+	// ReservationTerm should be empty for Consumption type
+	if item.ReservationTerm != "" {
+		t.Errorf("ReservationTerm: expected empty for Consumption, got %s", item.ReservationTerm)
+	}
+}
+
+func TestPriceItem_UnmarshalJSON_ReservationTerm(t *testing.T) {
+	var item PriceItem
+	if err := json.Unmarshal([]byte(sampleReservationPriceItemJSON), &item); err != nil {
+		t.Fatalf("failed to unmarshal reservation PriceItem: %v", err)
+	}
+
+	if item.Type != "Reservation" {
+		t.Errorf("Type: expected Reservation, got %s", item.Type)
+	}
+	if item.ReservationTerm != "1 Year" {
+		t.Errorf("ReservationTerm: expected '1 Year', got %s", item.ReservationTerm)
+	}
+	if item.RetailPrice != 3285.0 {
+		t.Errorf("RetailPrice: expected 3285.0, got %f", item.RetailPrice)
+	}
+}
+
+func TestPriceItem_UnmarshalJSON_MissingOptionalFields(t *testing.T) {
+	// Test that missing optional fields don't cause errors.
+	// Go's encoding/json handles:
+	// - Missing fields: left at zero value
+	// - null values: left at zero value for strings
+	// - Unknown fields: ignored by default
+
+	minimalJSON := `{
+		"retailPrice": 0.01,
+		"currencyCode": "USD",
+		"armRegionName": "westus"
+	}`
+
+	var item PriceItem
+	if err := json.Unmarshal([]byte(minimalJSON), &item); err != nil {
+		t.Fatalf("failed to unmarshal minimal PriceItem: %v", err)
+	}
+
+	// Required fields should be populated
+	if item.RetailPrice != 0.01 {
+		t.Errorf("RetailPrice: expected 0.01, got %f", item.RetailPrice)
+	}
+	if item.CurrencyCode != "USD" {
+		t.Errorf("CurrencyCode: expected USD, got %s", item.CurrencyCode)
+	}
+	if item.ArmRegionName != "westus" {
+		t.Errorf("ArmRegionName: expected westus, got %s", item.ArmRegionName)
+	}
+
+	// Optional/missing fields should be zero values
+	if item.Location != "" {
+		t.Errorf("Location: expected empty string for missing field, got %s", item.Location)
+	}
+	if item.ReservationTerm != "" {
+		t.Errorf("ReservationTerm: expected empty string for missing field, got %s", item.ReservationTerm)
+	}
+	if item.AvailabilityID != "" {
+		t.Errorf("AvailabilityID: expected empty string for missing field, got %s", item.AvailabilityID)
+	}
+	if item.UnitPrice != 0 {
+		t.Errorf("UnitPrice: expected 0 for missing field, got %f", item.UnitPrice)
+	}
+	if item.IsPrimaryMeterRegion {
+		t.Error("IsPrimaryMeterRegion: expected false for missing field")
+	}
+}
+
+func TestPriceItem_UnmarshalJSON_NullValues(t *testing.T) {
+	// Test explicit null values
+	jsonWithNulls := `{
+		"retailPrice": 0.01,
+		"currencyCode": "USD",
+		"armRegionName": "eastus",
+		"location": null,
+		"reservationTerm": null,
+		"availabilityId": null
+	}`
+
+	var item PriceItem
+	if err := json.Unmarshal([]byte(jsonWithNulls), &item); err != nil {
+		t.Fatalf("failed to unmarshal PriceItem with nulls: %v", err)
+	}
+
+	// null string values become empty strings in Go
+	if item.Location != "" {
+		t.Errorf("Location: expected empty string for null, got %s", item.Location)
+	}
+	if item.ReservationTerm != "" {
+		t.Errorf("ReservationTerm: expected empty string for null, got %s", item.ReservationTerm)
+	}
+	if item.AvailabilityID != "" {
+		t.Errorf("AvailabilityID: expected empty string for null, got %s", item.AvailabilityID)
+	}
+}
+
+func TestPriceItem_TypeSafety(t *testing.T) {
+	// Verify that pricing fields are correct Go types for calculations.
+	// This is a compile-time verification encoded as a test.
+
+	item := PriceItem{
+		RetailPrice:      0.0104,
+		UnitPrice:        0.0104,
+		TierMinimumUnits: 0.0,
+	}
+
+	// Verify float64 types allow arithmetic
+	var hourlyRate float64 = item.RetailPrice
+	var hoursPerMonth float64 = 730.0
+	monthlyCost := hourlyRate * hoursPerMonth
+	if monthlyCost < 7.0 || monthlyCost > 8.0 {
+		t.Errorf("float64 arithmetic failed: %f * %f = %f", hourlyRate, hoursPerMonth, monthlyCost)
+	}
+
+	// Verify string types
+	var _ string = item.MeterID
+	var _ string = item.ProductID
+	var _ string = item.SkuID
+	var _ string = item.ServiceID
+
+	// Verify bool type
+	var _ bool = item.IsPrimaryMeterRegion
+}
+
+func TestPriceItem_MarshalJSON(t *testing.T) {
+	item := PriceItem{
+		RetailPrice:          0.0104,
+		UnitPrice:            0.0104,
+		TierMinimumUnits:     0.0,
+		CurrencyCode:         "USD",
+		ArmRegionName:        "eastus",
+		Location:             "US East",
+		ArmSkuName:           "Standard_B1s",
+		SkuName:              "B1s",
+		SkuID:                "DZH318Z0BQPS/00TG",
+		ServiceName:          "Virtual Machines",
+		ServiceID:            "DZH313Z7MMC8",
+		ServiceFamily:        "Compute",
+		ProductName:          "Virtual Machines BS Series",
+		ProductID:            "DZH318Z0BQPS",
+		MeterID:              "000a794b-bdb0-58be-a0cd-0c3a0f222923",
+		MeterName:            "B1s",
+		UnitOfMeasure:        "1 Hour",
+		IsPrimaryMeterRegion: true,
+		EffectiveStartDate:   "2020-08-01T00:00:00Z",
+		Type:                 "Consumption",
+	}
+
+	jsonBytes, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal PriceItem: %v", err)
+	}
+
+	// Verify JSON uses camelCase field names (Azure API format)
+	jsonStr := string(jsonBytes)
+	expectedFields := []string{
+		`"retailPrice":`,
+		`"unitPrice":`,
+		`"currencyCode":`,
+		`"armRegionName":`,
+		`"location":`,
+		`"armSkuName":`,
+		`"serviceName":`,
+		`"isPrimaryMeterRegion":`,
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(jsonStr, field) {
+			t.Errorf("expected JSON to contain %s", field)
+		}
+	}
+}
+
+func TestPriceItem_MarshalJSON_OmitsEmptyOptional(t *testing.T) {
+	item := PriceItem{
+		RetailPrice:   0.01,
+		CurrencyCode:  "USD",
+		ArmRegionName: "eastus",
+		// ReservationTerm and AvailabilityID are empty
+	}
+
+	jsonBytes, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal PriceItem: %v", err)
+	}
+
+	jsonStr := string(jsonBytes)
+
+	// Fields with omitempty should not appear when empty
+	if strings.Contains(jsonStr, `"reservationTerm"`) {
+		t.Error("expected reservationTerm to be omitted when empty")
+	}
+	if strings.Contains(jsonStr, `"availabilityId"`) {
+		t.Error("expected availabilityId to be omitted when empty")
+	}
+}
+
+func TestPriceItem_RoundTrip(t *testing.T) {
+	// Test that unmarshal -> marshal -> unmarshal produces identical values
+	original := PriceItem{
+		RetailPrice:          0.0104,
+		UnitPrice:            0.0104,
+		TierMinimumUnits:     0.0,
+		CurrencyCode:         "USD",
+		ArmRegionName:        "eastus",
+		Location:             "US East",
+		ArmSkuName:           "Standard_B1s",
+		SkuName:              "B1s",
+		SkuID:                "DZH318Z0BQPS/00TG",
+		ServiceName:          "Virtual Machines",
+		ServiceID:            "DZH313Z7MMC8",
+		ServiceFamily:        "Compute",
+		ProductName:          "Virtual Machines BS Series",
+		ProductID:            "DZH318Z0BQPS",
+		MeterID:              "000a794b-bdb0-58be-a0cd-0c3a0f222923",
+		MeterName:            "B1s",
+		UnitOfMeasure:        "1 Hour",
+		IsPrimaryMeterRegion: true,
+		EffectiveStartDate:   "2020-08-01T00:00:00Z",
+		Type:                 "Consumption",
+		ReservationTerm:      "1 Year",
+		AvailabilityID:       "test-availability",
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Unmarshal back
+	var roundTripped PriceItem
+	if err := json.Unmarshal(jsonBytes, &roundTripped); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Compare values
+	if original.RetailPrice != roundTripped.RetailPrice {
+		t.Errorf("RetailPrice mismatch: %f != %f", original.RetailPrice, roundTripped.RetailPrice)
+	}
+	if original.CurrencyCode != roundTripped.CurrencyCode {
+		t.Errorf("CurrencyCode mismatch: %s != %s", original.CurrencyCode, roundTripped.CurrencyCode)
+	}
+	if original.ArmRegionName != roundTripped.ArmRegionName {
+		t.Errorf("ArmRegionName mismatch: %s != %s", original.ArmRegionName, roundTripped.ArmRegionName)
+	}
+	if original.Location != roundTripped.Location {
+		t.Errorf("Location mismatch: %s != %s", original.Location, roundTripped.Location)
+	}
+	if original.ReservationTerm != roundTripped.ReservationTerm {
+		t.Errorf("ReservationTerm mismatch: %s != %s", original.ReservationTerm, roundTripped.ReservationTerm)
+	}
+	if original.AvailabilityID != roundTripped.AvailabilityID {
+		t.Errorf("AvailabilityID mismatch: %s != %s", original.AvailabilityID, roundTripped.AvailabilityID)
+	}
+	if original.IsPrimaryMeterRegion != roundTripped.IsPrimaryMeterRegion {
+		t.Errorf("IsPrimaryMeterRegion mismatch: %v != %v",
+			original.IsPrimaryMeterRegion, roundTripped.IsPrimaryMeterRegion)
+	}
+}
+
+func TestPriceResponse_MarshalJSON(t *testing.T) {
+	resp := PriceResponse{
+		BillingCurrency:    "USD",
+		CustomerEntityID:   "Default",
+		CustomerEntityType: "Retail",
+		Items: []PriceItem{
+			{
+				RetailPrice:   0.01,
+				CurrencyCode:  "USD",
+				ArmRegionName: "eastus",
+			},
+		},
+		NextPageLink: "https://prices.azure.com/api/retail/prices?$skip=1000",
+		Count:        1,
+	}
+
+	jsonBytes, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal PriceResponse: %v", err)
+	}
+
+	// Verify JSON uses PascalCase field names (Azure API format for envelope)
+	jsonStr := string(jsonBytes)
+	expectedFields := []string{
+		`"BillingCurrency":`,
+		`"CustomerEntityId":`,
+		`"CustomerEntityType":`,
+		`"Items":`,
+		`"NextPageLink":`,
+		`"Count":`,
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(jsonStr, field) {
+			t.Errorf("expected JSON to contain %s", field)
+		}
+	}
+}
+
+func TestPriceResponse_RoundTrip(t *testing.T) {
+	original := PriceResponse{
+		BillingCurrency:    "EUR",
+		CustomerEntityID:   "TestEntity",
+		CustomerEntityType: "Retail",
+		Items: []PriceItem{
+			{
+				RetailPrice:   100.50,
+				CurrencyCode:  "EUR",
+				ArmRegionName: "westeurope",
+				Type:          "Consumption",
+			},
+			{
+				RetailPrice:     5000.00,
+				CurrencyCode:    "EUR",
+				ArmRegionName:   "westeurope",
+				Type:            "Reservation",
+				ReservationTerm: "3 Years",
+			},
+		},
+		NextPageLink: "",
+		Count:        2,
+	}
+
+	// Marshal
+	jsonBytes, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Unmarshal
+	var roundTripped PriceResponse
+	if err := json.Unmarshal(jsonBytes, &roundTripped); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Compare
+	if original.BillingCurrency != roundTripped.BillingCurrency {
+		t.Errorf("BillingCurrency mismatch")
+	}
+	if original.CustomerEntityID != roundTripped.CustomerEntityID {
+		t.Errorf("CustomerEntityID mismatch")
+	}
+	if original.Count != roundTripped.Count {
+		t.Errorf("Count mismatch: %d != %d", original.Count, roundTripped.Count)
+	}
+	if len(original.Items) != len(roundTripped.Items) {
+		t.Fatalf("Items length mismatch: %d != %d", len(original.Items), len(roundTripped.Items))
+	}
+	if original.Items[1].ReservationTerm != roundTripped.Items[1].ReservationTerm {
+		t.Errorf("Nested ReservationTerm mismatch")
+	}
+}

--- a/specs/007-azure-price-models/checklists/requirements.md
+++ b/specs/007-azure-price-models/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Azure Retail Prices API Data Models
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The spec focuses on data model requirements without prescribing implementation
+- All Azure API fields are documented with types and descriptions

--- a/specs/007-azure-price-models/data-model.md
+++ b/specs/007-azure-price-models/data-model.md
@@ -1,0 +1,313 @@
+# Data Model: Azure Retail Prices API
+
+**Feature**: 007-azure-price-models
+**Date**: 2026-02-03
+**Package**: `internal/azureclient`
+
+## Overview
+
+This document defines the Go struct definitions for the Azure Retail Prices API response format. These models enable type-safe JSON parsing of API responses.
+
+## Entity Relationship
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                      PriceResponse                          │
+│  (API response envelope)                                    │
+├─────────────────────────────────────────────────────────────┤
+│  BillingCurrency    : string                                │
+│  CustomerEntityID   : string                                │
+│  CustomerEntityType : string                                │
+│  Items              : []PriceItem  ─────────┐               │
+│  NextPageLink       : string                │               │
+│  Count              : int                   │               │
+└─────────────────────────────────────────────│───────────────┘
+                                              │
+                                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        PriceItem                            │
+│  (Individual pricing record)                                │
+├─────────────────────────────────────────────────────────────┤
+│  Pricing:                                                   │
+│    RetailPrice      : float64                               │
+│    UnitPrice        : float64                               │
+│    TierMinimumUnits : float64                               │
+│    CurrencyCode     : string                                │
+│                                                             │
+│  Resource:                                                  │
+│    ArmRegionName    : string                                │
+│    Location         : string                                │
+│    ArmSkuName       : string                                │
+│    SkuName          : string                                │
+│    SkuID            : string                                │
+│                                                             │
+│  Service:                                                   │
+│    ServiceName      : string                                │
+│    ServiceID        : string                                │
+│    ServiceFamily    : string                                │
+│    ProductName      : string                                │
+│    ProductID        : string                                │
+│                                                             │
+│  Meter:                                                     │
+│    MeterID          : string                                │
+│    MeterName        : string                                │
+│    UnitOfMeasure    : string                                │
+│    IsPrimaryMeterRegion : bool                              │
+│                                                             │
+│  Temporal:                                                  │
+│    EffectiveStartDate : string (ISO8601)                    │
+│                                                             │
+│  Type:                                                      │
+│    Type             : string                                │
+│    ReservationTerm  : string (optional)                     │
+│                                                             │
+│  Optional:                                                  │
+│    AvailabilityID   : string (often empty)                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Struct Definitions
+
+### PriceResponse
+
+```go
+// PriceResponse represents the envelope returned by the Azure Retail Prices API.
+// It contains a paginated list of price items along with metadata.
+//
+// The API returns up to 1000 items per request. When NextPageLink is non-empty,
+// additional pages are available.
+//
+// Example response:
+//
+//	{
+//	  "BillingCurrency": "USD",
+//	  "CustomerEntityId": "Default",
+//	  "CustomerEntityType": "Retail",
+//	  "Items": [...],
+//	  "NextPageLink": "https://prices.azure.com/api/retail/prices?$skip=1000",
+//	  "Count": 1000
+//	}
+type PriceResponse struct {
+    // BillingCurrency is the currency code for all prices in the response.
+    // Typically "USD" unless a different currency was requested.
+    BillingCurrency string `json:"BillingCurrency"`
+
+    // CustomerEntityID identifies the customer entity for pricing.
+    // Default value is "Default" for retail pricing.
+    CustomerEntityID string `json:"CustomerEntityId"`
+
+    // CustomerEntityType indicates the type of pricing returned.
+    // Value is "Retail" for the public retail prices API.
+    CustomerEntityType string `json:"CustomerEntityType"`
+
+    // Items contains the price entries for this page of results.
+    // Maximum 1000 items per response.
+    Items []PriceItem `json:"Items"`
+
+    // NextPageLink is the URL to fetch the next page of results.
+    // Empty string indicates no more pages are available.
+    NextPageLink string `json:"NextPageLink"`
+
+    // Count is the number of items in this page of results.
+    Count int `json:"Count"`
+}
+```
+
+### PriceItem
+
+```go
+// PriceItem represents a single price entry from the Azure Retail Prices API.
+// Each item corresponds to a specific SKU/meter combination in a region.
+//
+// Field names match Azure API JSON field names using json struct tags.
+// All fields use Go types appropriate for their JSON counterparts.
+//
+// Example:
+//
+//	{
+//	  "currencyCode": "USD",
+//	  "retailPrice": 0.0104,
+//	  "armRegionName": "eastus",
+//	  "skuName": "B1s",
+//	  "serviceName": "Virtual Machines",
+//	  "type": "Consumption"
+//	}
+type PriceItem struct {
+    // === Pricing Information ===
+
+    // RetailPrice is the Microsoft retail price without any discount.
+    // This is the list price for the resource.
+    RetailPrice float64 `json:"retailPrice"`
+
+    // UnitPrice is the price per unit of measure.
+    // For most resources, this equals RetailPrice.
+    UnitPrice float64 `json:"unitPrice"`
+
+    // TierMinimumUnits is the minimum units of consumption for this price tier.
+    // Value is 0 for non-tiered pricing.
+    TierMinimumUnits float64 `json:"tierMinimumUnits"`
+
+    // CurrencyCode is the ISO 4217 currency code for the price (e.g., "USD").
+    CurrencyCode string `json:"currencyCode"`
+
+    // === Resource Identification ===
+
+    // ArmRegionName is the Azure Resource Manager region identifier (e.g., "eastus").
+    // This is the programmatic region name used in ARM templates.
+    ArmRegionName string `json:"armRegionName"`
+
+    // Location is the human-readable Azure datacenter location (e.g., "US East").
+    // This is the display name shown in the Azure portal.
+    Location string `json:"location"`
+
+    // ArmSkuName is the SKU identifier used in Azure Resource Manager (e.g., "Standard_B1s").
+    // This is the value used when provisioning resources via ARM.
+    ArmSkuName string `json:"armSkuName"`
+
+    // SkuName is the display name for the SKU (e.g., "B1s").
+    // This is a human-friendly version of the SKU identifier.
+    SkuName string `json:"skuName"`
+
+    // SkuID is the unique identifier for this SKU (e.g., "DZH318Z0BQPS/00TG").
+    SkuID string `json:"skuId"`
+
+    // === Service Classification ===
+
+    // ServiceName is the name of the Azure service (e.g., "Virtual Machines").
+    ServiceName string `json:"serviceName"`
+
+    // ServiceID is the unique identifier for the Azure service.
+    ServiceID string `json:"serviceId"`
+
+    // ServiceFamily is the service category (e.g., "Compute", "Storage", "Networking").
+    ServiceFamily string `json:"serviceFamily"`
+
+    // ProductName is the full product name (e.g., "Virtual Machines BS Series").
+    ProductName string `json:"productName"`
+
+    // ProductID is the unique identifier for the product.
+    ProductID string `json:"productId"`
+
+    // === Meter Information ===
+
+    // MeterID is the unique identifier for the billing meter (UUID format).
+    // This is used in Azure cost management and billing.
+    MeterID string `json:"meterId"`
+
+    // MeterName is the human-readable name for the meter (e.g., "B1s").
+    MeterName string `json:"meterName"`
+
+    // UnitOfMeasure describes the billing unit (e.g., "1 Hour", "1 GB", "10K Transactions").
+    UnitOfMeasure string `json:"unitOfMeasure"`
+
+    // IsPrimaryMeterRegion indicates whether this is the primary region for the meter.
+    // When true, this region is used for billing purposes.
+    IsPrimaryMeterRegion bool `json:"isPrimaryMeterRegion"`
+
+    // === Temporal Data ===
+
+    // EffectiveStartDate is when this price became effective (ISO 8601 format).
+    // Example: "2020-08-01T00:00:00Z"
+    EffectiveStartDate string `json:"effectiveStartDate"`
+
+    // === Pricing Type ===
+
+    // Type indicates the pricing model for this item.
+    // Values: "Consumption", "Reservation", "DevTestConsumption"
+    Type string `json:"type"`
+
+    // ReservationTerm is the commitment period for reservation pricing.
+    // Only present when Type is "Reservation".
+    // Values: "1 Year", "3 Years"
+    ReservationTerm string `json:"reservationTerm,omitempty"`
+
+    // === Optional Fields ===
+
+    // AvailabilityID is the availability identifier.
+    // Often empty or null in API responses.
+    AvailabilityID string `json:"availabilityId,omitempty"`
+}
+```
+
+### PriceQuery (existing, no changes)
+
+```go
+// PriceQuery contains filter parameters for querying prices.
+// All fields are optional; empty values are not included in the filter.
+type PriceQuery struct {
+    // ArmRegionName filters by Azure region (e.g., "eastus").
+    ArmRegionName string
+
+    // ArmSkuName filters by SKU name (e.g., "Standard_B1s").
+    ArmSkuName string
+
+    // ServiceName filters by service (e.g., "Virtual Machines").
+    ServiceName string
+
+    // ProductName filters by product name.
+    ProductName string
+
+    // CurrencyCode filters by currency (default: "USD").
+    CurrencyCode string
+}
+```
+
+## Field Type Decisions
+
+| JSON Type | Go Type | Rationale |
+|-----------|---------|-----------|
+| number (decimal) | `float64` | Prices require decimal precision |
+| number (integer) | `int` | Count is always whole numbers |
+| string | `string` | Most fields are strings |
+| boolean | `bool` | Direct mapping |
+| null | `omitempty` tag | Allows graceful handling of missing/null values |
+| ISO 8601 date | `string` | Preserves format, avoids timezone parsing |
+
+## Validation Rules
+
+### PriceResponse
+
+- `Items` may be empty but not nil after unmarshaling
+- `NextPageLink` is empty string (not nil) when no more pages
+- `Count` should equal `len(Items)` but this is not enforced
+
+### PriceItem
+
+- `RetailPrice` and `UnitPrice` are non-negative
+- `CurrencyCode` is 3-letter ISO code
+- `Type` is one of: "Consumption", "Reservation", "DevTestConsumption"
+- `ReservationTerm` only populated when `Type == "Reservation"`
+- `EffectiveStartDate` is ISO 8601 format
+
+## JSON Mapping Verification
+
+| Go Field | JSON Field | Direction |
+|----------|------------|-----------|
+| `BillingCurrency` | `BillingCurrency` | ↔ |
+| `CustomerEntityID` | `CustomerEntityId` | ↔ |
+| `CustomerEntityType` | `CustomerEntityType` | ↔ |
+| `Items` | `Items` | ↔ |
+| `NextPageLink` | `NextPageLink` | ↔ |
+| `Count` | `Count` | ↔ |
+| `RetailPrice` | `retailPrice` | ↔ |
+| `UnitPrice` | `unitPrice` | ↔ |
+| `TierMinimumUnits` | `tierMinimumUnits` | ↔ |
+| `CurrencyCode` | `currencyCode` | ↔ |
+| `ArmRegionName` | `armRegionName` | ↔ |
+| `Location` | `location` | ↔ |
+| `ArmSkuName` | `armSkuName` | ↔ |
+| `SkuName` | `skuName` | ↔ |
+| `SkuID` | `skuId` | ↔ |
+| `ServiceName` | `serviceName` | ↔ |
+| `ServiceID` | `serviceId` | ↔ |
+| `ServiceFamily` | `serviceFamily` | ↔ |
+| `ProductName` | `productName` | ↔ |
+| `ProductID` | `productId` | ↔ |
+| `MeterID` | `meterId` | ↔ |
+| `MeterName` | `meterName` | ↔ |
+| `UnitOfMeasure` | `unitOfMeasure` | ↔ |
+| `IsPrimaryMeterRegion` | `isPrimaryMeterRegion` | ↔ |
+| `EffectiveStartDate` | `effectiveStartDate` | ↔ |
+| `Type` | `type` | ↔ |
+| `ReservationTerm` | `reservationTerm` | ↔ |
+| `AvailabilityID` | `availabilityId` | ↔ |

--- a/specs/007-azure-price-models/plan.md
+++ b/specs/007-azure-price-models/plan.md
@@ -1,0 +1,231 @@
+# Implementation Plan: Azure Retail Prices API Data Models
+
+**Branch**: `007-azure-price-models` | **Date**: 2026-02-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-azure-price-models/spec.md`
+
+## Summary
+
+Enhance existing Azure Retail Prices API data models in `internal/azureclient/types.go` to:
+
+1. Add missing fields documented in Azure API (`location`, `reservationTerm`, `availabilityId`)
+2. Export `PriceResponse` struct for external package usage
+3. Add comprehensive godoc documentation for all fields
+4. Add dedicated unit tests for JSON marshaling/unmarshaling
+
+The models already exist with 18 fields implemented. Adding 3 missing fields brings total to 21. This is an enhancement, not a greenfield implementation.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: `encoding/json` (stdlib), `github.com/rs/zerolog` (logging)
+**Storage**: N/A - stateless plugin (in-memory only)
+**Testing**: `go test` with table-driven tests, race detector
+**Target Platform**: Linux server (gRPC plugin)
+**Project Type**: Single project (Go module)
+**Performance Goals**: Standard JSON marshaling (<1ms for typical responses)
+**Constraints**: No authenticated Azure APIs, no persistent storage
+**Scale/Scope**: ~20 fields per PriceItem, responses up to 1000 items
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with `.specify/memory/constitution.md`:
+
+- [x] **Code Quality**: Plan includes linting checks (`make lint`), error handling via JSON decode errors, no complex functions (data structs only)
+- [x] **Testing**: Plan includes TDD workflow (tests first), ≥80% coverage target for models, no concurrent code requiring race detector
+- [x] **User Experience**: N/A for data models - no plugin lifecycle changes
+- [x] **Documentation**: Plan includes godoc comments for all exported types and fields
+- [x] **Performance**: Standard JSON marshaling performance, no special optimization needed
+- [x] **Architectural Constraints**: Plan DOES NOT violate "Hard No's":
+  - ✅ No authenticated Azure APIs (models only, no API calls)
+  - ✅ No persistent storage (pure data structures)
+  - ✅ No infrastructure mutation (read-only types)
+  - ✅ No bulk data embedding (types, not data)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-azure-price-models/
+├── plan.md              # This file
+├── research.md          # Phase 0 output - Azure API field analysis
+├── data-model.md        # Phase 1 output - struct definitions
+├── quickstart.md        # Phase 1 output - usage examples
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+└── azureclient/
+    ├── types.go         # MODIFY: Add missing fields, export PriceResponse, add godoc
+    └── types_test.go    # CREATE: Dedicated JSON marshal/unmarshal tests
+```
+
+**Structure Decision**: Modify existing `internal/azureclient/types.go` file. The models are already co-located with the HTTP client that uses them. No new packages needed.
+
+## Complexity Tracking
+
+No violations. This is a straightforward enhancement of existing data structures.
+
+## Existing Code Analysis
+
+### Current State (`internal/azureclient/types.go`)
+
+**Implemented:**
+
+- `Config` struct - client configuration (complete)
+- `PriceQuery` struct - query parameters (complete)
+- `PriceItem` struct - 18 fields implemented
+- `priceResponse` struct - unexported, has all envelope fields
+
+**Missing from PriceItem (per Azure API docs):**
+
+| Field | Type | Status |
+|-------|------|--------|
+| `location` | string | Missing |
+| `availabilityId` | *string | Missing (nullable) |
+| `reservationTerm` | string | Missing (optional for reservations) |
+| `savingsPlan` | []SavingsPlanPrice | Missing (preview API only) |
+
+**Issues to Address:**
+
+1. `priceResponse` is unexported → Export as `PriceResponse`
+2. No godoc comments on individual fields → Add comprehensive documentation
+3. No dedicated unit tests for marshaling → Create `types_test.go`
+
+## Implementation Tasks
+
+### Task 1: Add Missing Fields to PriceItem
+
+Add the following fields to `PriceItem`:
+
+```go
+// Location is the human-readable Azure datacenter location (e.g., "US East").
+Location string `json:"location"`
+
+// AvailabilityID is the optional availability identifier.
+// May be empty or null in API responses.
+AvailabilityID string `json:"availabilityId,omitempty"`
+
+// ReservationTerm is the commitment term for reservation pricing.
+// Only present when Type is "Reservation" (e.g., "1 Year", "3 Years").
+ReservationTerm string `json:"reservationTerm,omitempty"`
+```
+
+### Task 2: Export PriceResponse
+
+Rename `priceResponse` to `PriceResponse` and add godoc:
+
+```go
+// PriceResponse represents the envelope returned by the Azure Retail Prices API.
+// It contains a paginated list of price items along with metadata.
+//
+// Example JSON response:
+//
+//	{
+//	  "BillingCurrency": "USD",
+//	  "CustomerEntityId": "Default",
+//	  "CustomerEntityType": "Retail",
+//	  "Items": [...],
+//	  "NextPageLink": "https://prices.azure.com/...",
+//	  "Count": 100
+//	}
+type PriceResponse struct {
+    // BillingCurrency is the currency code for all prices in the response.
+    BillingCurrency string `json:"BillingCurrency"`
+
+    // CustomerEntityID identifies the customer entity.
+    CustomerEntityID string `json:"CustomerEntityId"`
+
+    // CustomerEntityType indicates the type of pricing (e.g., "Retail").
+    CustomerEntityType string `json:"CustomerEntityType"`
+
+    // Items contains the price entries for this page of results.
+    Items []PriceItem `json:"Items"`
+
+    // NextPageLink is the URL to fetch the next page of results.
+    // Empty string indicates no more pages.
+    NextPageLink string `json:"NextPageLink"`
+
+    // Count is the number of items in this page.
+    Count int `json:"Count"`
+}
+```
+
+### Task 3: Add Godoc Comments to All PriceItem Fields
+
+Add descriptive comments to every field explaining:
+
+- What the field represents
+- Example values where helpful
+- Any constraints or optionality
+
+### Task 4: Create types_test.go
+
+Create dedicated tests for JSON marshaling:
+
+1. `TestPriceItem_UnmarshalJSON` - Verify all fields populated from sample JSON
+2. `TestPriceItem_MarshalJSON` - Verify round-trip produces equivalent JSON
+3. `TestPriceItem_MissingOptionalFields` - Verify graceful handling of nulls/missing
+4. `TestPriceResponse_UnmarshalJSON` - Verify envelope parsing
+5. `TestPriceResponse_Pagination` - Verify NextPageLink handling
+
+### Task 5: Update client.go References
+
+Update `client.go` to use exported `PriceResponse` instead of `priceResponse`.
+
+## Test Strategy
+
+### Unit Tests (types_test.go)
+
+```go
+func TestPriceItem_UnmarshalJSON(t *testing.T) {
+    // Table-driven test with real Azure API sample JSON
+    // Verify all 21+ fields are correctly populated
+}
+
+func TestPriceItem_RoundTrip(t *testing.T) {
+    // Create struct → marshal → unmarshal → compare
+    // Ensures JSON tags are bidirectionally correct
+}
+
+func TestPriceItem_MissingOptionalFields(t *testing.T) {
+    // JSON without reservationTerm, availabilityId
+    // Verify no error, fields are zero values
+}
+
+func TestPriceResponse_UnmarshalJSON(t *testing.T) {
+    // Full response envelope with Items array
+    // Verify Count, NextPageLink, Items populated
+}
+```
+
+### Integration Tests
+
+Existing integration tests in `examples/` already cover end-to-end API calls. No new integration tests needed for data models.
+
+## Success Metrics
+
+| Criteria | Target | Verification |
+|----------|--------|--------------|
+| Field accuracy | 100% | All Azure API fields mapped |
+| Round-trip fidelity | 100% | Unmarshal→Marshal produces equivalent JSON |
+| Test coverage | ≥80% | `go test -cover ./internal/azureclient/...` |
+| Godoc quality | All fields | Manual review of `go doc` output |
+| Lint compliance | 0 errors | `make lint` passes |
+
+## Dependencies
+
+None. This feature has no external dependencies beyond stdlib `encoding/json`.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Azure API adds new fields | Medium | Low | Use `json:",omitempty"` for optional fields; unknown fields ignored by default |
+| Breaking change to client.go | Low | Medium | Rename is internal; update all references in same commit |
+| Field type mismatch | Low | High | Validate against real API responses in integration tests |

--- a/specs/007-azure-price-models/quickstart.md
+++ b/specs/007-azure-price-models/quickstart.md
@@ -1,0 +1,289 @@
+# Quickstart: Azure Retail Prices API Data Models
+
+**Feature**: 007-azure-price-models
+**Package**: `github.com/rshade/finfocus-plugin-azure-public/internal/azureclient`
+
+## Overview
+
+The `azureclient` package provides Go structs for working with the Azure Retail Prices API. These models enable type-safe JSON parsing of API responses.
+
+## Basic Usage
+
+### Querying Prices
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/rshade/finfocus-plugin-azure-public/internal/azureclient"
+)
+
+func main() {
+    // Create client with default configuration
+    config := azureclient.DefaultConfig()
+    client, err := azureclient.NewClient(config)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+
+    // Query prices for a specific VM SKU
+    query := azureclient.PriceQuery{
+        ArmRegionName: "eastus",
+        ArmSkuName:    "Standard_B1s",
+        ServiceName:   "Virtual Machines",
+        CurrencyCode:  "USD",
+    }
+
+    prices, err := client.GetPrices(context.Background(), query)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Access pricing data with type safety
+    for _, item := range prices {
+        fmt.Printf("SKU: %s\n", item.SkuName)
+        fmt.Printf("Region: %s (%s)\n", item.Location, item.ArmRegionName)
+        fmt.Printf("Price: %.4f %s per %s\n",
+            item.RetailPrice,
+            item.CurrencyCode,
+            item.UnitOfMeasure)
+        fmt.Printf("Type: %s\n", item.Type)
+        fmt.Println("---")
+    }
+}
+```
+
+### Working with Response Envelope
+
+```go
+import (
+    "encoding/json"
+    "fmt"
+)
+
+// Parse a raw API response
+func parseResponse(jsonData []byte) (*azureclient.PriceResponse, error) {
+    var response azureclient.PriceResponse
+    if err := json.Unmarshal(jsonData, &response); err != nil {
+        return nil, err
+    }
+
+    fmt.Printf("Currency: %s\n", response.BillingCurrency)
+    fmt.Printf("Items: %d\n", response.Count)
+
+    if response.NextPageLink != "" {
+        fmt.Printf("More pages available: %s\n", response.NextPageLink)
+    }
+
+    return &response, nil
+}
+```
+
+### Handling Different Pricing Types
+
+```go
+func categorizePrices(items []azureclient.PriceItem) {
+    var consumption, reservation []azureclient.PriceItem
+
+    for _, item := range items {
+        switch item.Type {
+        case "Consumption":
+            consumption = append(consumption, item)
+        case "Reservation":
+            reservation = append(reservation, item)
+            // Access reservation-specific field
+            fmt.Printf("Reservation term: %s\n", item.ReservationTerm)
+        }
+    }
+
+    fmt.Printf("Consumption prices: %d\n", len(consumption))
+    fmt.Printf("Reservation prices: %d\n", len(reservation))
+}
+```
+
+### Creating Test Data
+
+```go
+func createMockPriceItem() azureclient.PriceItem {
+    return azureclient.PriceItem{
+        // Pricing
+        RetailPrice:      0.0104,
+        UnitPrice:        0.0104,
+        TierMinimumUnits: 0,
+        CurrencyCode:     "USD",
+
+        // Resource
+        ArmRegionName: "eastus",
+        Location:      "US East",
+        ArmSkuName:    "Standard_B1s",
+        SkuName:       "B1s",
+        SkuID:         "DZH318Z0BQPS/00TG",
+
+        // Service
+        ServiceName:   "Virtual Machines",
+        ServiceID:     "DZH313Z7MMC8",
+        ServiceFamily: "Compute",
+        ProductName:   "Virtual Machines BS Series",
+        ProductID:     "DZH318Z0BQPS",
+
+        // Meter
+        MeterID:              "000a794b-bdb0-58be-a0cd-0c3a0f222923",
+        MeterName:            "B1s",
+        UnitOfMeasure:        "1 Hour",
+        IsPrimaryMeterRegion: true,
+
+        // Temporal
+        EffectiveStartDate: "2020-08-01T00:00:00Z",
+
+        // Type
+        Type: "Consumption",
+    }
+}
+
+func createMockResponse() azureclient.PriceResponse {
+    return azureclient.PriceResponse{
+        BillingCurrency:    "USD",
+        CustomerEntityID:   "Default",
+        CustomerEntityType: "Retail",
+        Items: []azureclient.PriceItem{
+            createMockPriceItem(),
+        },
+        NextPageLink: "",
+        Count:        1,
+    }
+}
+```
+
+### JSON Round-Trip
+
+```go
+import (
+    "encoding/json"
+    "fmt"
+)
+
+func roundTripDemo() {
+    // Create a price item
+    original := createMockPriceItem()
+
+    // Marshal to JSON
+    jsonBytes, err := json.MarshalIndent(original, "", "  ")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("JSON:\n%s\n", string(jsonBytes))
+
+    // Unmarshal back to struct
+    var parsed azureclient.PriceItem
+    if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
+        panic(err)
+    }
+
+    // Verify round-trip
+    if original.RetailPrice == parsed.RetailPrice &&
+       original.ArmRegionName == parsed.ArmRegionName {
+        fmt.Println("Round-trip successful!")
+    }
+}
+```
+
+## Common Patterns
+
+### Filter by Service Family
+
+```go
+func filterByServiceFamily(items []azureclient.PriceItem, family string) []azureclient.PriceItem {
+    var filtered []azureclient.PriceItem
+    for _, item := range items {
+        if item.ServiceFamily == family {
+            filtered = append(filtered, item)
+        }
+    }
+    return filtered
+}
+
+// Usage
+computePrices := filterByServiceFamily(prices, "Compute")
+storagePrices := filterByServiceFamily(prices, "Storage")
+```
+
+### Calculate Monthly Cost
+
+```go
+func calculateMonthlyCost(item azureclient.PriceItem, hoursPerMonth float64) float64 {
+    // Only for hourly pricing
+    if item.UnitOfMeasure != "1 Hour" {
+        return 0 // Handle other units differently
+    }
+    return item.RetailPrice * hoursPerMonth
+}
+
+// Usage: 730 hours in a typical month
+monthlyCost := calculateMonthlyCost(vmPrice, 730)
+fmt.Printf("Estimated monthly cost: $%.2f\n", monthlyCost)
+```
+
+### Find Cheapest Option
+
+```go
+func findCheapestByRegion(items []azureclient.PriceItem) map[string]azureclient.PriceItem {
+    cheapest := make(map[string]azureclient.PriceItem)
+
+    for _, item := range items {
+        if item.Type != "Consumption" {
+            continue // Only compare consumption pricing
+        }
+
+        existing, found := cheapest[item.ArmRegionName]
+        if !found || item.RetailPrice < existing.RetailPrice {
+            cheapest[item.ArmRegionName] = item
+        }
+    }
+
+    return cheapest
+}
+```
+
+## Field Reference
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `RetailPrice` | List price per unit | `0.0104` |
+| `CurrencyCode` | ISO currency | `"USD"` |
+| `ArmRegionName` | Region identifier | `"eastus"` |
+| `Location` | Display name | `"US East"` |
+| `SkuName` | SKU display name | `"B1s"` |
+| `ArmSkuName` | ARM SKU identifier | `"Standard_B1s"` |
+| `ServiceName` | Azure service | `"Virtual Machines"` |
+| `ServiceFamily` | Category | `"Compute"` |
+| `UnitOfMeasure` | Billing unit | `"1 Hour"` |
+| `Type` | Pricing model | `"Consumption"` |
+| `ReservationTerm` | Commitment (if reservation) | `"1 Year"` |
+
+## Error Handling
+
+```go
+prices, err := client.GetPrices(ctx, query)
+if err != nil {
+    switch {
+    case errors.Is(err, azureclient.ErrRateLimited):
+        // Handle rate limiting
+        log.Println("Rate limited, retry later")
+    case errors.Is(err, azureclient.ErrServiceUnavailable):
+        // Handle service unavailability
+        log.Println("Azure API unavailable")
+    case errors.Is(err, azureclient.ErrInvalidResponse):
+        // Handle malformed response
+        log.Println("Invalid API response")
+    default:
+        // Handle other errors
+        log.Printf("Error: %v\n", err)
+    }
+    return
+}
+```

--- a/specs/007-azure-price-models/research.md
+++ b/specs/007-azure-price-models/research.md
@@ -1,0 +1,236 @@
+# Research: Azure Retail Prices API Data Models
+
+**Feature**: 007-azure-price-models
+**Date**: 2026-02-03
+**Source**: [Azure Retail Prices API Documentation](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices)
+
+## Executive Summary
+
+The Azure Retail Prices API (`https://prices.azure.com/api/retail/prices`) returns pricing data in a well-documented JSON format. The existing implementation in `internal/azureclient/types.go` covers 18 of 22+ documented fields. This research documents all available fields and identifies gaps.
+
+## Azure API Response Structure
+
+### Response Envelope
+
+| Field | Type | Description | Present in Code |
+|-------|------|-------------|-----------------|
+| `BillingCurrency` | string | Currency for all prices | ✅ Yes |
+| `CustomerEntityId` | string | Customer entity identifier | ✅ Yes |
+| `CustomerEntityType` | string | Entity type (e.g., "Retail") | ✅ Yes |
+| `Items` | array | Array of PriceItem objects | ✅ Yes |
+| `NextPageLink` | string | URL for next page (empty if none) | ✅ Yes |
+| `Count` | int | Number of items in this page | ✅ Yes |
+
+**Decision**: Response envelope is complete. Export as `PriceResponse` for external use.
+
+### PriceItem Fields
+
+#### Core Pricing Fields
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `retailPrice` | float64 | `0.0104` | ✅ | Retail price without discount |
+| `unitPrice` | float64 | `0.0104` | ✅ | Same as retailPrice for most cases |
+| `tierMinimumUnits` | float64 | `0` | ✅ | Min units for tiered pricing |
+| `currencyCode` | string | `"USD"` | ✅ | ISO currency code |
+
+#### Resource Identification
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `armRegionName` | string | `"eastus"` | ✅ | ARM region identifier |
+| `location` | string | `"US East"` | ❌ | Human-readable location |
+| `armSkuName` | string | `"Standard_B1s"` | ✅ | ARM SKU identifier |
+| `skuName` | string | `"B1s"` | ✅ | SKU display name |
+| `skuId` | string | `"DZH318Z0BQPS/00TG"` | ✅ | Unique SKU identifier |
+
+#### Service Classification
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `serviceName` | string | `"Virtual Machines"` | ✅ | Azure service name |
+| `serviceId` | string | `"DZH313Z7MMC8"` | ✅ | Unique service identifier |
+| `serviceFamily` | string | `"Compute"` | ✅ | Service category |
+| `productName` | string | `"Virtual Machines BS Series"` | ✅ | Product display name |
+| `productId` | string | `"DZH318Z0BQPS"` | ✅ | Unique product identifier |
+
+#### Meter Information
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `meterId` | string | `"000a794b-bdb0-..."` | ✅ | Unique meter identifier (UUID) |
+| `meterName` | string | `"B1s"` | ✅ | Human-readable meter name |
+| `unitOfMeasure` | string | `"1 Hour"` | ✅ | Billing unit description |
+| `isPrimaryMeterRegion` | bool | `true` | ✅ | Primary region for billing |
+
+#### Temporal Data
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `effectiveStartDate` | string | `"2020-08-01T00:00:00Z"` | ✅ | ISO8601 timestamp |
+
+#### Pricing Type
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `type` | string | `"Consumption"` | ✅ | Pricing type |
+| `reservationTerm` | string | `"1 Year"` | ❌ | Only for type="Reservation" |
+
+#### Optional Fields
+
+| Field | Type | Example | Present | Notes |
+|-------|------|---------|---------|-------|
+| `availabilityId` | string | `null` | ❌ | Often null in responses |
+
+#### Preview API Fields (v2023-01-01-preview)
+
+| Field | Type | Description | Present | Notes |
+|-------|------|-------------|---------|-------|
+| `savingsPlan` | array | Savings plan pricing options | ❌ | Only in preview API |
+
+## Decisions
+
+### Decision 1: Add Missing Fields
+
+**Decision**: Add `location`, `reservationTerm`, and `availabilityId` fields.
+
+**Rationale**:
+
+- `location` provides human-readable region names useful for display
+- `reservationTerm` is required to distinguish 1-year vs 3-year reservation pricing
+- `availabilityId` is in the API response (even if often null)
+
+**Alternatives Considered**:
+
+- Skip `availabilityId` since it's usually null → Rejected; better to have complete model
+- Add `savingsPlan` for preview API → Deferred; not needed for current use cases
+
+### Decision 2: Export PriceResponse
+
+**Decision**: Rename `priceResponse` to `PriceResponse` (exported).
+
+**Rationale**:
+
+- External packages may need to work with response envelopes
+- Consistent with Go convention of exporting public API types
+- Enables mocking in tests without accessing internal types
+
+**Alternatives Considered**:
+
+- Keep unexported, add accessor methods → Rejected; overly complex for simple data
+- Create separate `models` package → Rejected; types belong with client that uses them
+
+### Decision 3: String Type for Dates
+
+**Decision**: Keep `effectiveStartDate` as `string`, not `time.Time`.
+
+**Rationale**:
+
+- Preserves exact API format for round-trip fidelity
+- Avoids timezone parsing complexity
+- Callers can parse as needed with `time.Parse()`
+
+**Alternatives Considered**:
+
+- Use `time.Time` with custom unmarshaler → Rejected; adds complexity, breaks round-trip
+- Use `*time.Time` for optionality → Rejected; string handles empty case naturally
+
+### Decision 4: Omit savingsPlan
+
+**Decision**: Do not implement `savingsPlan` field in this iteration.
+
+**Rationale**:
+
+- Requires preview API version (`api-version=2023-01-01-preview`)
+- Current implementation uses GA API
+- Can be added later when savings plan support is needed
+
+**Alternatives Considered**:
+
+- Add as `json.RawMessage` for forward compatibility → Rejected; unused fields add noise
+- Support both API versions → Rejected; scope creep for data model task
+
+## Sample JSON for Testing
+
+### Complete PriceItem Example
+
+```json
+{
+  "currencyCode": "USD",
+  "tierMinimumUnits": 0.0,
+  "retailPrice": 0.0104,
+  "unitPrice": 0.0104,
+  "armRegionName": "eastus",
+  "location": "US East",
+  "effectiveStartDate": "2020-08-01T00:00:00Z",
+  "meterId": "000a794b-bdb0-58be-a0cd-0c3a0f222923",
+  "meterName": "B1s",
+  "productId": "DZH318Z0BQPS",
+  "skuId": "DZH318Z0BQPS/00TG",
+  "availabilityId": null,
+  "productName": "Virtual Machines BS Series",
+  "skuName": "B1s",
+  "serviceName": "Virtual Machines",
+  "serviceId": "DZH313Z7MMC8",
+  "serviceFamily": "Compute",
+  "unitOfMeasure": "1 Hour",
+  "type": "Consumption",
+  "isPrimaryMeterRegion": true,
+  "armSkuName": "Standard_B1s"
+}
+```
+
+### Reservation PriceItem Example
+
+```json
+{
+  "currencyCode": "USD",
+  "tierMinimumUnits": 0.0,
+  "retailPrice": 3285.0,
+  "unitPrice": 3285.0,
+  "armRegionName": "eastus",
+  "location": "US East",
+  "effectiveStartDate": "2023-01-01T00:00:00Z",
+  "meterId": "abc123-reservation-meter",
+  "meterName": "D2s v3 Reserved",
+  "productId": "DZH318Z0BQPS",
+  "skuId": "DZH318Z0BQPS/RESV",
+  "productName": "Virtual Machines Dv3 Series",
+  "skuName": "D2s v3",
+  "serviceName": "Virtual Machines",
+  "serviceId": "DZH313Z7MMC8",
+  "serviceFamily": "Compute",
+  "unitOfMeasure": "1 Year",
+  "type": "Reservation",
+  "reservationTerm": "1 Year",
+  "isPrimaryMeterRegion": true,
+  "armSkuName": "Standard_D2s_v3"
+}
+```
+
+### Complete Response Envelope Example
+
+```json
+{
+  "BillingCurrency": "USD",
+  "CustomerEntityId": "Default",
+  "CustomerEntityType": "Retail",
+  "Items": [
+    {
+      "currencyCode": "USD",
+      "retailPrice": 0.0104,
+      "armRegionName": "eastus",
+      "skuName": "B1s",
+      "type": "Consumption"
+    }
+  ],
+  "NextPageLink": "https://prices.azure.com/api/retail/prices?$skip=1000",
+  "Count": 1
+}
+```
+
+## References
+
+- [Azure Retail Prices API Documentation](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices)
+- [OData Query Options](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices#odata-query-options)
+- [Savings Plans Preview API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices#savings-plans)

--- a/specs/007-azure-price-models/spec.md
+++ b/specs/007-azure-price-models/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: Azure Retail Prices API Data Models
+
+**Feature Branch**: `007-azure-price-models`
+**Created**: 2026-02-03
+**Status**: Draft
+**Input**: GitHub Issue #8 - Define Go structs for Azure Retail Prices API request/response data structures with proper JSON marshaling tags.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - HTTP Client Response Parsing (Priority: P1)
+
+As the HTTP client, I want to unmarshal JSON responses from the Azure Retail Prices API into strongly-typed Go structs so that I can work with pricing data in a type-safe manner.
+
+**Why this priority**: This is the foundational capability. Without proper response parsing, no pricing queries can function. All downstream features depend on this.
+
+**Independent Test**: Can be fully tested by providing sample JSON from the Azure API and verifying all fields are correctly populated in the Go structs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid JSON response from Azure Retail Prices API, **When** the response is unmarshaled into PriceResponse, **Then** all fields (Items, NextPageLink, Count) are correctly populated
+2. **Given** a JSON response with multiple pricing items, **When** unmarshaled, **Then** each PriceItem contains correct values for retailPrice, currencyCode, armRegionName, and all other fields
+3. **Given** a JSON response with a NextPageLink, **When** unmarshaled, **Then** the NextPageLink field contains the pagination URL for fetching additional results
+
+---
+
+### User Story 2 - Type-Safe Field Access (Priority: P1)
+
+As cost estimation logic, I want type-safe access to pricing fields so that I can perform calculations without runtime type errors.
+
+**Why this priority**: Equally critical as parsing - type safety prevents calculation errors and enables IDE support for developers.
+
+**Independent Test**: Can be tested by writing code that accesses all pricing fields and verifying compile-time type checking works correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a populated PriceItem struct, **When** accessing retailPrice, **Then** the value is a float64 suitable for arithmetic operations
+2. **Given** a populated PriceItem struct, **When** accessing string fields (currencyCode, armRegionName, etc.), **Then** values are properly typed strings
+3. **Given** a PriceItem with all fields populated, **When** performing price calculations, **Then** no type assertions or conversions are required
+
+---
+
+### User Story 3 - Mock Data Construction (Priority: P2)
+
+As a test writer, I want to construct mock pricing data easily so that I can write comprehensive tests without calling the live Azure API.
+
+**Why this priority**: Important for testing but builds on the foundation of the struct definitions from P1 stories.
+
+**Independent Test**: Can be tested by creating PriceItem structs with known values and marshaling them to JSON to verify correctness.
+
+**Acceptance Scenarios**:
+
+1. **Given** a need for test data, **When** constructing a PriceItem struct literal, **Then** all fields can be easily populated with test values
+2. **Given** a constructed PriceItem, **When** marshaled to JSON, **Then** the output matches the expected Azure API format
+3. **Given** a PriceResponse with mock items, **When** used in tests, **Then** it behaves identically to real API responses
+
+---
+
+### User Story 4 - Field Documentation (Priority: P3)
+
+As a developer, I want struct tags and godoc comments documenting field meanings so that I understand what each field represents without consulting external documentation.
+
+**Why this priority**: Documentation improves developer experience but is not required for functionality.
+
+**Independent Test**: Can be verified by reviewing godoc output and ensuring each field has descriptive comments.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PriceItem struct definition, **When** viewing godoc, **Then** each field has a descriptive comment explaining its purpose
+2. **Given** the PriceResponse struct, **When** viewing example documentation, **Then** a sample JSON response is included showing the expected format
+
+---
+
+### Edge Cases
+
+- What happens when optional fields are missing from the JSON response? (System should handle gracefully with zero values)
+- How does the system handle unknown/additional fields in the response? (JSON unmarshaling should ignore unknown fields)
+- What happens with null values in numeric fields? (Should default to zero value for the type)
+- How are pagination responses handled when there are no more pages? (NextPageLink should be empty string)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST define a `PriceResponse` struct with fields: Items ([]PriceItem), NextPageLink (string), Count (int)
+- **FR-002**: System MUST define a `PriceItem` struct containing all essential pricing fields from the Azure Retail Prices API
+- **FR-003**: All struct fields MUST have JSON struct tags matching the exact field names in the Azure API response (camelCase)
+- **FR-004**: Numeric fields (retailPrice, unitPrice, tierMinimumUnits) MUST be typed as float64
+- **FR-005**: String identifier fields (meterId, productId, skuId) MUST be typed as string
+- **FR-006**: Date fields (effectiveStartDate) MUST be typed as string to preserve ISO8601 format
+- **FR-007**: System MUST support JSON round-trip (unmarshal then marshal produces equivalent JSON)
+- **FR-008**: System MUST handle missing optional fields gracefully during unmarshaling (use Go zero values)
+
+### Key Entities
+
+- **PriceResponse**: Top-level container for API responses. Contains a collection of pricing items, pagination link for fetching additional results, and total count of items.
+- **PriceItem**: Individual pricing record representing a single SKU/meter combination. Contains pricing information (retailPrice, unitPrice), resource identification (armRegionName, productName, skuName), service categorization (serviceName, serviceFamily), and billing metadata (unitOfMeasure, type).
+
+### PriceItem Required Fields
+
+Based on Azure Retail Prices API documentation:
+
+| Field               | Go Type | JSON Tag              | Description                                        |
+| ------------------- | ------- | --------------------- | -------------------------------------------------- |
+| currencyCode        | string  | `currencyCode`        | ISO currency code (e.g., "USD")                    |
+| tierMinimumUnits    | float64 | `tierMinimumUnits`    | Minimum units for tiered pricing                   |
+| retailPrice         | float64 | `retailPrice`         | Listed retail price                                |
+| unitPrice           | float64 | `unitPrice`           | Price per unit of measure                          |
+| armRegionName       | string  | `armRegionName`       | Azure region identifier (e.g., "eastus")           |
+| location            | string  | `location`            | Human-readable location (e.g., "US East")          |
+| effectiveStartDate  | string  | `effectiveStartDate`  | ISO8601 timestamp when price became effective      |
+| meterId             | string  | `meterId`             | Unique meter identifier (UUID)                     |
+| meterName           | string  | `meterName`           | Human-readable meter name                          |
+| productId           | string  | `productId`           | Unique product identifier (UUID)                   |
+| skuId               | string  | `skuId`               | Unique SKU identifier (UUID)                       |
+| productName         | string  | `productName`         | Product display name                               |
+| skuName             | string  | `skuName`             | SKU display name                                   |
+| serviceName         | string  | `serviceName`         | Azure service name                                 |
+| serviceFamily       | string  | `serviceFamily`       | Service category                                   |
+| unitOfMeasure       | string  | `unitOfMeasure`       | Billing unit description                           |
+| type                | string  | `type`                | Pricing type (e.g., "Consumption", "Reservation")  |
+| isPrimaryMeterRegion| bool    | `isPrimaryMeterRegion`| Whether this is the primary region for the meter   |
+| armSkuName          | string  | `armSkuName`          | ARM SKU identifier                                 |
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All JSON fields from the Azure Retail Prices API response are correctly mapped to Go struct fields with 100% accuracy
+- **SC-002**: JSON unmarshaling succeeds for sample responses containing all documented field types
+- **SC-003**: JSON round-trip (unmarshal → marshal → unmarshal) produces identical struct values
+- **SC-004**: Missing optional fields in JSON responses result in Go zero values without errors
+- **SC-005**: Unit test coverage for data models reaches at least 80%
+- **SC-006**: All struct fields have descriptive godoc comments
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations (≥80% for business logic)
+- [x] Error handling strategy is defined (no silent failures)
+- [x] Code complexity is considered (functions <15 cyclomatic complexity)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then format)
+- [x] Integration test needs identified (external API interactions) - N/A for pure data models
+- [x] Performance test criteria specified (if applicable) - N/A for data structures
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable - N/A for data models
+- [x] Response time expectations defined - N/A for data structures
+- [x] Observability requirements specified - N/A for data models
+
+### Documentation
+
+- [x] README.md updates identified - N/A (internal package)
+- [x] API documentation needs outlined (godoc comments for all fields)
+- [x] Examples/quickstart guide planned - Example JSON in godoc
+
+### Performance & Reliability
+
+- [x] Performance targets specified - Standard JSON marshaling performance
+- [x] Reliability requirements defined - Graceful handling of missing fields
+- [x] Resource constraints considered - No special constraints for data models
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The Azure Retail Prices API response format is stable and follows the documented schema
+- All UUID fields in the API response are string-formatted (not binary UUIDs)
+- Date/time fields use ISO8601 string format and will be parsed as strings (not time.Time) to preserve exact format
+- The `type` field uses "type" as the JSON key despite being a Go reserved word (handled with json tag)
+- Pagination uses NextPageLink URL for fetching additional results; empty string indicates no more pages

--- a/specs/007-azure-price-models/tasks.md
+++ b/specs/007-azure-price-models/tasks.md
@@ -1,0 +1,273 @@
+# Tasks: Azure Retail Prices API Data Models
+
+**Input**: Design documents from `/specs/007-azure-price-models/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅
+
+**Tests**: TDD workflow specified in constitution - tests FIRST, ≥80% coverage target.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Project structure**: `internal/azureclient/` (existing package)
+- Files to modify: `types.go`, `client.go`
+- Files to create: `types_test.go`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No setup required - modifying existing codebase
+
+*This feature enhances existing code. No project initialization needed.*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Export PriceResponse struct - blocks all user story tests
+
+**⚠️ CRITICAL**: User story tests cannot use `PriceResponse` until it's exported
+
+- [x] T001 Export `priceResponse` as `PriceResponse` in internal/azureclient/types.go
+- [x] T002 Update client.go to use exported `PriceResponse` in internal/azureclient/client.go
+
+**Checkpoint**: PriceResponse is now exported and usable by tests
+
+---
+
+## Phase 3: User Story 1 - HTTP Client Response Parsing (Priority: P1) 🎯 MVP
+
+**Goal**: Unmarshal JSON responses from Azure Retail Prices API into strongly-typed Go structs
+
+**Independent Test**: Provide sample JSON from Azure API and verify all fields are correctly populated
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T003 [P] [US1] Create test file with TestPriceResponse_UnmarshalJSON in internal/azureclient/types_test.go
+- [x] T004 [P] [US1] Add TestPriceItem_UnmarshalJSON_AllFields to verify all 21 fields unmarshal correctly in internal/azureclient/types_test.go
+- [x] T005 [P] [US1] Add TestPriceItem_UnmarshalJSON_MissingOptionalFields for graceful null/missing handling in internal/azureclient/types_test.go (Note: Go's encoding/json handles unknown fields by ignoring them and null numerics as zero values by default - document this behavior in test comments)
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Add `Location` field to PriceItem struct in internal/azureclient/types.go
+- [x] T007 [US1] Add `ReservationTerm` field with omitempty tag to PriceItem struct in internal/azureclient/types.go
+- [x] T008 [US1] Add `AvailabilityID` field with omitempty tag to PriceItem struct in internal/azureclient/types.go
+- [x] T009 [US1] Verify all tests pass with `go test ./internal/azureclient/... -run TestPrice`
+
+**Checkpoint**: JSON unmarshaling works for all Azure API response formats
+
+---
+
+## Phase 4: User Story 2 - Type-Safe Field Access (Priority: P1)
+
+**Goal**: Ensure correct Go types for all pricing fields to enable calculations without type assertions
+
+**Independent Test**: Write code accessing all fields and verify compile-time type checking
+
+### Tests for User Story 2
+
+- [x] T010 [P] [US2] Add TestPriceItem_TypeSafety to verify float64/string/bool types in internal/azureclient/types_test.go
+
+### Verification for User Story 2 (No Code Changes - Checkpoint Only)
+
+- [x] T011 [US2] **CHECKPOINT**: Confirm RetailPrice, UnitPrice, TierMinimumUnits are float64 in internal/azureclient/types.go
+- [x] T012 [US2] **CHECKPOINT**: Confirm MeterID, ProductID, SkuID, ServiceID are string in internal/azureclient/types.go
+- [x] T013 [US2] **CHECKPOINT**: Confirm IsPrimaryMeterRegion is bool in internal/azureclient/types.go
+
+**Checkpoint**: All field types are correct for calculations and IDE support
+
+---
+
+## Phase 5: User Story 3 - Mock Data Construction (Priority: P2)
+
+**Goal**: Enable test writers to construct mock pricing data and marshal to JSON
+
+**Independent Test**: Create PriceItem structs and marshal to JSON, verify output format
+
+### Tests for User Story 3
+
+- [x] T014 [P] [US3] Add TestPriceItem_MarshalJSON to verify JSON output format in internal/azureclient/types_test.go
+- [x] T015 [P] [US3] Add TestPriceItem_RoundTrip to verify unmarshal→marshal→unmarshal produces identical values in internal/azureclient/types_test.go
+- [x] T016 [P] [US3] Add TestPriceResponse_MarshalJSON to verify envelope format in internal/azureclient/types_test.go
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] Verify json tags on all PriceItem fields match Azure API camelCase format in internal/azureclient/types.go
+- [x] T018 [US3] Verify json tags on all PriceResponse fields match Azure API PascalCase format in internal/azureclient/types.go
+- [x] T019 [US3] Run round-trip tests and fix any JSON tag mismatches
+
+**Checkpoint**: Structs can be marshaled to JSON matching Azure API format
+
+---
+
+## Phase 6: User Story 4 - Field Documentation (Priority: P3)
+
+**Goal**: Add godoc comments to all struct fields explaining their purpose
+
+**Independent Test**: Run `go doc` and verify each field has descriptive documentation
+
+### Tests for User Story 4
+
+*No automated tests - manual godoc review*
+
+### Implementation for User Story 4
+
+- [x] T020 [P] [US4] Add godoc comment to PriceResponse struct with example JSON in internal/azureclient/types.go
+- [x] T021 [P] [US4] Add godoc comments to all PriceResponse fields in internal/azureclient/types.go
+- [x] T022 [P] [US4] Add godoc comment to PriceItem struct with example JSON in internal/azureclient/types.go
+- [x] T023 [P] [US4] Add godoc comments to all PriceItem pricing fields (RetailPrice, UnitPrice, etc.) in internal/azureclient/types.go
+- [x] T024 [P] [US4] Add godoc comments to all PriceItem resource fields (ArmRegionName, Location, etc.) in internal/azureclient/types.go
+- [x] T025 [P] [US4] Add godoc comments to all PriceItem service fields (ServiceName, ServiceFamily, etc.) in internal/azureclient/types.go
+- [x] T026 [P] [US4] Add godoc comments to all PriceItem meter fields (MeterID, MeterName, etc.) in internal/azureclient/types.go
+- [x] T027 [P] [US4] Add godoc comments to PriceItem optional fields (ReservationTerm, AvailabilityID) in internal/azureclient/types.go
+
+**Checkpoint**: All exported types and fields have descriptive godoc comments
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and constitution compliance
+
+### Constitution Compliance Tasks
+
+- [x] T028 [P] Run `make lint` and fix all linting issues
+- [x] T029 [P] Verify test coverage ≥80% with `go test -cover ./internal/azureclient/...`
+- [x] T030 [P] Verify `go doc github.com/rshade/finfocus-plugin-azure-public/internal/azureclient` output is complete
+- [x] T031 [P] Run existing client tests to ensure no regressions: `go test ./internal/azureclient/...`
+
+### Final Validation
+
+- [x] T032 Run full test suite with `make test`
+- [x] T033 Update CLAUDE.md with new model documentation if needed
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: N/A - no setup needed
+- **Phase 2 (Foundational)**: No dependencies - MUST complete before user stories
+- **Phase 3 (US1)**: Depends on Phase 2 (needs exported PriceResponse for tests)
+- **Phase 4 (US2)**: Depends on Phase 3 (type verification after fields added)
+- **Phase 5 (US3)**: Depends on Phase 3 (marshal tests need complete fields)
+- **Phase 6 (US4)**: Depends on Phase 3 (document all fields after they exist)
+- **Phase 7 (Polish)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Foundational only - core parsing functionality
+- **User Story 2 (P1)**: Can run parallel with US1 after foundational
+- **User Story 3 (P2)**: Depends on US1 fields being complete
+- **User Story 4 (P3)**: Can run parallel with US3 after US1
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation tasks can often run in parallel within a story
+- Verification task runs last to confirm tests pass
+
+### Parallel Opportunities
+
+**Phase 2**:
+- T001, T002 are sequential (T002 depends on T001)
+
+**Phase 3 (US1)**:
+- T003, T004, T005 can run in parallel (all create tests)
+- T006, T007, T008 can run in parallel (different fields)
+
+**Phase 5 (US3)**:
+- T014, T015, T016 can run in parallel (all test tasks)
+
+**Phase 6 (US4)**:
+- T020-T027 can ALL run in parallel (different comment sections)
+
+**Phase 7**:
+- T028, T029, T030, T031 can all run in parallel
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Launch all US1 test tasks together:
+Task: "Create test file with TestPriceResponse_UnmarshalJSON in internal/azureclient/types_test.go"
+Task: "Add TestPriceItem_UnmarshalJSON_AllFields in internal/azureclient/types_test.go"
+Task: "Add TestPriceItem_UnmarshalJSON_MissingOptionalFields in internal/azureclient/types_test.go"
+
+# Then launch all US1 field additions together:
+Task: "Add Location field to PriceItem struct in internal/azureclient/types.go"
+Task: "Add ReservationTerm field to PriceItem struct in internal/azureclient/types.go"
+Task: "Add AvailabilityID field to PriceItem struct in internal/azureclient/types.go"
+```
+
+---
+
+## Parallel Example: User Story 4 Documentation
+
+```bash
+# Launch ALL documentation tasks together (all different comment sections):
+Task: "Add godoc comment to PriceResponse struct in internal/azureclient/types.go"
+Task: "Add godoc comments to all PriceResponse fields in internal/azureclient/types.go"
+Task: "Add godoc comment to PriceItem struct in internal/azureclient/types.go"
+Task: "Add godoc comments to all PriceItem pricing fields in internal/azureclient/types.go"
+Task: "Add godoc comments to all PriceItem resource fields in internal/azureclient/types.go"
+Task: "Add godoc comments to all PriceItem service fields in internal/azureclient/types.go"
+Task: "Add godoc comments to all PriceItem meter fields in internal/azureclient/types.go"
+Task: "Add godoc comments to PriceItem optional fields in internal/azureclient/types.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2 Only)
+
+1. Complete Phase 2: Export PriceResponse
+2. Complete Phase 3: US1 - JSON unmarshaling
+3. Complete Phase 4: US2 - Type safety verification
+4. **STOP and VALIDATE**: Run `make test` - all tests pass
+5. Feature is functional for HTTP client use
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready
+2. + US1 → JSON parsing works (MVP!)
+3. + US2 → Type safety verified
+4. + US3 → Mock data construction works
+5. + US4 → Full documentation
+6. + Polish → Production ready
+
+### Single Developer Strategy
+
+Execute in order: Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6 → Phase 7
+
+Estimated task count per phase:
+- Phase 2: 2 tasks
+- Phase 3: 7 tasks
+- Phase 4: 4 tasks
+- Phase 5: 6 tasks
+- Phase 6: 8 tasks
+- Phase 7: 6 tasks
+- **Total: 33 tasks**
+
+---
+
+## Notes
+
+- [P] tasks = different files OR different sections, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Existing tests in `client_test.go` already cover some marshaling - don't duplicate
+- Focus `types_test.go` on dedicated model testing
+- Use sample JSON from `research.md` for test data
+- Commit after each completed user story phase


### PR DESCRIPTION
## Summary

- Export `PriceResponse` struct for external package consumption
- Add three missing fields to `PriceItem`: `Location` (display name), `ReservationTerm` (commitment period), and `AvailabilityID`
- Comprehensive godoc documentation for all exported types and fields
- New `types_test.go` with 11 tests covering JSON marshal/unmarshal, type safety, round-trip fidelity, and optional field handling

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes (all 67 tests in azureclient package)
- [x] Test coverage at 91.2% (exceeds 80% target)
- [x] `go doc` output verified for completeness

## Changes

### New files

- `internal/azureclient/types_test.go` - Unit tests for PriceItem and PriceResponse JSON serialization
- `specs/007-azure-price-models/` - Feature specification and task tracking

### Modified files

- `internal/azureclient/types.go` - Added Location, ReservationTerm, AvailabilityID fields; exported PriceResponse; added godoc comments
- `internal/azureclient/client.go` - Updated to use exported PriceResponse
- `internal/azureclient/client_test.go` - Updated to use exported PriceResponse

Closes #8