### PR TITLE
feat(azureclient): add OData filter query builder with fluent API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@
 - N/A - stateless plugin (in-memory only) (006-http-client-retry)
 - Go 1.25.5 + `encoding/json` (stdlib), `github.com/rs/zerolog` (logging) (007-azure-price-models)
 - Go 1.25.5 + `github.com/hashicorp/go-retryablehttp` (HTTP retry), (008-azure-error-handling)
+- Go 1.25.5 + None new — pure Go stdlib (`fmt`, `strings`, `sort`) (009-odata-filter-builder)
+- N/A — pure data transformation (string builder), no I/O (009-odata-filter-builder)
 
 ## Recent Changes
 - 002-grpc-server-port: Added Go 1.25.5
@@ -66,6 +68,31 @@ query := azureclient.PriceQuery{
     CurrencyCode:  "USD",
 }
 prices, err := client.GetPrices(ctx, query)
+```
+
+**FilterBuilder (OData `$filter`)**:
+
+```go
+// Basic AND filter (default priceType=Consumption is always included)
+filter := azureclient.NewFilterBuilder().
+    Region("eastus").
+    Service("Virtual Machines").
+    SKU("Standard_B1s").
+    Build()
+// armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s'
+//   and priceType eq 'Consumption' and serviceName eq 'Virtual Machines'
+
+// OR grouping + generic fields + explicit type override
+filter = azureclient.NewFilterBuilder().
+    Or(
+        azureclient.Region("eastus"),
+        azureclient.Region("westus2"),
+    ).
+    Field("meterName", "B1s").
+    Type("Reservation").
+    Build()
+// (armRegionName eq 'eastus' or armRegionName eq 'westus2')
+//   and meterName eq 'B1s' and priceType eq 'Reservation'
 ```
 
 **Retry Policy**:

--- a/internal/azureclient/client.go
+++ b/internal/azureclient/client.go
@@ -396,31 +396,13 @@ func extractResponseSnippet(err error) string {
 	return snippet
 }
 
-// escapeODataString escapes a string for use in an OData filter.
-// Single quotes are escaped by doubling them (OData standard).
-func escapeODataString(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
-}
-
 // buildFilterQuery builds an OData filter query from a PriceQuery.
 func buildFilterQuery(query PriceQuery) string {
-	var filters []string
-
-	if query.ArmRegionName != "" {
-		filters = append(filters, fmt.Sprintf("armRegionName eq '%s'", escapeODataString(query.ArmRegionName)))
-	}
-	if query.ArmSkuName != "" {
-		filters = append(filters, fmt.Sprintf("armSkuName eq '%s'", escapeODataString(query.ArmSkuName)))
-	}
-	if query.ServiceName != "" {
-		filters = append(filters, fmt.Sprintf("serviceName eq '%s'", escapeODataString(query.ServiceName)))
-	}
-	if query.ProductName != "" {
-		filters = append(filters, fmt.Sprintf("productName eq '%s'", escapeODataString(query.ProductName)))
-	}
-	if query.CurrencyCode != "" {
-		filters = append(filters, fmt.Sprintf("currencyCode eq '%s'", escapeODataString(query.CurrencyCode)))
-	}
-
-	return strings.Join(filters, " and ")
+	return NewFilterBuilder().
+		Region(query.ArmRegionName).
+		SKU(query.ArmSkuName).
+		Service(query.ServiceName).
+		ProductName(query.ProductName).
+		CurrencyCode(query.CurrencyCode).
+		Build()
 }

--- a/internal/azureclient/client_test.go
+++ b/internal/azureclient/client_test.go
@@ -394,8 +394,9 @@ func TestBuildFilterQuery_Empty(t *testing.T) {
 	query := PriceQuery{}
 	filter := buildFilterQuery(query)
 
-	if filter != "" {
-		t.Errorf("expected empty filter, got %s", filter)
+	expected := "priceType eq 'Consumption'"
+	if filter != expected {
+		t.Errorf("expected %s, got %s", expected, filter)
 	}
 }
 
@@ -403,7 +404,7 @@ func TestBuildFilterQuery_SingleField(t *testing.T) {
 	query := PriceQuery{ArmRegionName: "eastus"}
 	filter := buildFilterQuery(query)
 
-	expected := "armRegionName eq 'eastus'"
+	expected := "armRegionName eq 'eastus' and priceType eq 'Consumption'"
 	if filter != expected {
 		t.Errorf("expected %s, got %s", expected, filter)
 	}
@@ -421,6 +422,9 @@ func TestBuildFilterQuery_MultipleFields(t *testing.T) {
 	}
 	if !strings.Contains(filter, "armSkuName eq 'Standard_B1s'") {
 		t.Error("expected armSkuName filter")
+	}
+	if !strings.Contains(filter, "priceType eq 'Consumption'") {
+		t.Error("expected default priceType filter")
 	}
 	if !strings.Contains(filter, " and ") {
 		t.Error("expected 'and' between filters")
@@ -440,6 +444,7 @@ func TestBuildFilterQuery_AllFields(t *testing.T) {
 	expectedParts := []string{
 		"armRegionName eq 'eastus'",
 		"armSkuName eq 'Standard_B1s'",
+		"priceType eq 'Consumption'",
 		"serviceName eq 'Virtual Machines'",
 		"productName eq 'Virtual Machines BS Series'",
 		"currencyCode eq 'USD'",
@@ -458,7 +463,7 @@ func TestBuildFilterQuery_ODataEscape(t *testing.T) {
 	filter := buildFilterQuery(query)
 
 	// Single quotes should be doubled in OData
-	expected := "armRegionName eq 'east''us'"
+	expected := "armRegionName eq 'east''us' and priceType eq 'Consumption'"
 	if filter != expected {
 		t.Errorf("expected %s, got %s", expected, filter)
 	}
@@ -468,7 +473,7 @@ func TestBuildFilterQuery_ODataEscapeMultipleQuotes(t *testing.T) {
 	query := PriceQuery{ServiceName: "test'service'name"}
 	filter := buildFilterQuery(query)
 
-	expected := "serviceName eq 'test''service''name'"
+	expected := "priceType eq 'Consumption' and serviceName eq 'test''service''name'"
 	if filter != expected {
 		t.Errorf("expected %s, got %s", expected, filter)
 	}
@@ -480,7 +485,7 @@ func TestBuildFilterQuery_ODataInjectionPrevention(t *testing.T) {
 	filter := buildFilterQuery(query)
 
 	// The injection should be neutralized by escaping
-	expected := "armRegionName eq 'east'' or ''a'' eq ''a'"
+	expected := "armRegionName eq 'east'' or ''a'' eq ''a' and priceType eq 'Consumption'"
 	if filter != expected {
 		t.Errorf("expected injection to be neutralized: got %s", filter)
 	}

--- a/internal/azureclient/filter.go
+++ b/internal/azureclient/filter.go
@@ -1,0 +1,296 @@
+package azureclient
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const defaultPriceType = "Consumption"
+
+// FilterCondition represents a single OData equality condition.
+type FilterCondition struct {
+	// Field is the OData field name (for example, armRegionName).
+	Field string
+	// Value is the OData value.
+	Value string
+}
+
+// Region creates a condition for armRegionName.
+func Region(value string) FilterCondition {
+	return FilterCondition{Field: "armRegionName", Value: value}
+}
+
+// Service creates a condition for serviceName.
+func Service(value string) FilterCondition {
+	return FilterCondition{Field: "serviceName", Value: value}
+}
+
+// SKU creates a condition for armSkuName.
+func SKU(value string) FilterCondition {
+	return FilterCondition{Field: "armSkuName", Value: value}
+}
+
+// PriceType creates a condition for priceType.
+func PriceType(value string) FilterCondition {
+	return FilterCondition{Field: "priceType", Value: value}
+}
+
+// ProductName creates a condition for productName.
+func ProductName(value string) FilterCondition {
+	return FilterCondition{Field: "productName", Value: value}
+}
+
+// CurrencyCode creates a condition for currencyCode.
+func CurrencyCode(value string) FilterCondition {
+	return FilterCondition{Field: "currencyCode", Value: value}
+}
+
+// Condition creates a condition for an arbitrary OData field name.
+func Condition(field, value string) FilterCondition {
+	return FilterCondition{Field: field, Value: value}
+}
+
+// FilterBuilder builds deterministic OData $filter expressions.
+//
+// Named methods contribute AND conditions with last-write-wins semantics.
+// Or() contributes OR groups that are parenthesized when they contain
+// multiple conditions. The builder always includes a priceType filter:
+// "Consumption" by default, or the value set via Type().
+type FilterBuilder struct {
+	andConditions map[string]string
+	orGroups      [][]FilterCondition
+	typeValue     *string
+	genericFields []FilterCondition
+}
+
+type filterPart struct {
+	primaryField string
+	expression   string
+}
+
+// NewFilterBuilder creates a new filter builder.
+func NewFilterBuilder() *FilterBuilder {
+	return &FilterBuilder{
+		andConditions: make(map[string]string),
+		orGroups:      make([][]FilterCondition, 0),
+		genericFields: make([]FilterCondition, 0),
+	}
+}
+
+// Region sets armRegionName using AND semantics.
+func (b *FilterBuilder) Region(value string) *FilterBuilder {
+	return b.setNamedCondition("armRegionName", value)
+}
+
+// Service sets serviceName using AND semantics.
+func (b *FilterBuilder) Service(value string) *FilterBuilder {
+	return b.setNamedCondition("serviceName", value)
+}
+
+// SKU sets armSkuName using AND semantics.
+func (b *FilterBuilder) SKU(value string) *FilterBuilder {
+	return b.setNamedCondition("armSkuName", value)
+}
+
+// Type sets an explicit priceType. Blank values are ignored.
+func (b *FilterBuilder) Type(value string) *FilterBuilder {
+	if b == nil || isBlank(value) {
+		return b
+	}
+
+	b.typeValue = &value
+	return b
+}
+
+// ProductName sets productName using AND semantics.
+func (b *FilterBuilder) ProductName(value string) *FilterBuilder {
+	return b.setNamedCondition("productName", value)
+}
+
+// CurrencyCode sets currencyCode using AND semantics.
+func (b *FilterBuilder) CurrencyCode(value string) *FilterBuilder {
+	return b.setNamedCondition("currencyCode", value)
+}
+
+// Field appends an arbitrary AND condition. Blank names/values are ignored.
+func (b *FilterBuilder) Field(name, value string) *FilterBuilder {
+	if b == nil || isBlank(name) || isBlank(value) {
+		return b
+	}
+
+	b.genericFields = append(b.genericFields, FilterCondition{Field: name, Value: value})
+	return b
+}
+
+// Or appends a new OR group containing non-blank conditions.
+func (b *FilterBuilder) Or(conditions ...FilterCondition) *FilterBuilder {
+	if b == nil || len(conditions) == 0 {
+		return b
+	}
+
+	group := make([]FilterCondition, 0, len(conditions))
+	for _, condition := range conditions {
+		if isBlank(condition.Field) || isBlank(condition.Value) {
+			continue
+		}
+		group = append(group, condition)
+	}
+
+	if len(group) == 0 {
+		return b
+	}
+
+	b.orGroups = append(b.orGroups, group)
+	return b
+}
+
+// Build renders the OData $filter expression.
+//
+// Output is deterministic and sorted by primary field name, then expression.
+// Values are escaped using OData single-quote escaping (single quote -> double).
+func (b *FilterBuilder) Build() string {
+	if b == nil {
+		return fmt.Sprintf("priceType eq '%s'", defaultPriceType)
+	}
+
+	parts := b.buildParts()
+
+	expressions := make([]string, 0, len(parts))
+	for _, part := range parts {
+		expressions = append(expressions, part.expression)
+	}
+	return strings.Join(expressions, " and ")
+}
+
+func (b *FilterBuilder) buildParts() []filterPart {
+	parts := make([]filterPart, 0, len(b.andConditions)+len(b.genericFields)+len(b.orGroups)+1)
+	parts = append(parts, b.andParts()...)
+	parts = append(parts, b.genericParts()...)
+	parts = append(parts, b.orParts()...)
+	parts = append(parts, b.typePart())
+	sortFilterParts(parts)
+	return parts
+}
+
+func (b *FilterBuilder) andParts() []filterPart {
+	parts := make([]filterPart, 0, len(b.andConditions))
+	for field, value := range b.andConditions {
+		if isBlank(field) || isBlank(value) {
+			continue
+		}
+		parts = append(parts, filterPart{
+			primaryField: field,
+			expression:   formatCondition(field, value),
+		})
+	}
+	return parts
+}
+
+func (b *FilterBuilder) genericParts() []filterPart {
+	parts := make([]filterPart, 0, len(b.genericFields))
+	for _, condition := range b.genericFields {
+		if isBlank(condition.Field) || isBlank(condition.Value) {
+			continue
+		}
+		parts = append(parts, filterPart{
+			primaryField: condition.Field,
+			expression:   formatCondition(condition.Field, condition.Value),
+		})
+	}
+	return parts
+}
+
+func (b *FilterBuilder) orParts() []filterPart {
+	parts := make([]filterPart, 0, len(b.orGroups))
+	for _, group := range b.orGroups {
+		part, ok := buildORPart(group)
+		if !ok {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func (b *FilterBuilder) typePart() filterPart {
+	typeValue := defaultPriceType
+	if b.typeValue != nil && !isBlank(*b.typeValue) {
+		typeValue = *b.typeValue
+	}
+
+	return filterPart{
+		primaryField: "priceType",
+		expression:   formatCondition("priceType", typeValue),
+	}
+}
+
+func (b *FilterBuilder) setNamedCondition(field, value string) *FilterBuilder {
+	if b == nil || isBlank(value) {
+		return b
+	}
+
+	b.andConditions[field] = value
+	return b
+}
+
+func filterValidConditions(conditions []FilterCondition) []FilterCondition {
+	valid := make([]FilterCondition, 0, len(conditions))
+	for _, condition := range conditions {
+		if isBlank(condition.Field) || isBlank(condition.Value) {
+			continue
+		}
+		valid = append(valid, condition)
+	}
+	return valid
+}
+
+func buildORPart(group []FilterCondition) (filterPart, bool) {
+	conditions := filterValidConditions(group)
+	if len(conditions) == 0 {
+		return filterPart{}, false
+	}
+
+	sort.SliceStable(conditions, func(i, j int) bool {
+		if conditions[i].Field == conditions[j].Field {
+			return conditions[i].Value < conditions[j].Value
+		}
+		return conditions[i].Field < conditions[j].Field
+	})
+
+	expressions := make([]string, 0, len(conditions))
+	for _, condition := range conditions {
+		expressions = append(expressions, formatCondition(condition.Field, condition.Value))
+	}
+
+	expression := expressions[0]
+	if len(expressions) > 1 {
+		expression = "(" + strings.Join(expressions, " or ") + ")"
+	}
+
+	return filterPart{
+		primaryField: conditions[0].Field,
+		expression:   expression,
+	}, true
+}
+
+func sortFilterParts(parts []filterPart) {
+	sort.SliceStable(parts, func(i, j int) bool {
+		if parts[i].primaryField == parts[j].primaryField {
+			return parts[i].expression < parts[j].expression
+		}
+		return parts[i].primaryField < parts[j].primaryField
+	})
+}
+
+func formatCondition(field, value string) string {
+	return fmt.Sprintf("%s eq '%s'", field, escapeODataValue(value))
+}
+
+func escapeODataValue(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func isBlank(value string) bool {
+	return strings.TrimSpace(value) == ""
+}

--- a/internal/azureclient/filter_test.go
+++ b/internal/azureclient/filter_test.go
@@ -1,0 +1,563 @@
+package azureclient
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEscapeODataValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty string", input: "", want: ""},
+		{name: "no quotes", input: "eastus", want: "eastus"},
+		{name: "single quote", input: "O'Brien", want: "O''Brien"},
+		{name: "multiple quotes", input: "a'b'c", want: "a''b''c"},
+		{name: "consecutive quotes", input: "a''b", want: "a''''b"},
+		{name: "value with spaces", input: "Virtual Machines", want: "Virtual Machines"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeODataValue(tt.input)
+			if got != tt.want {
+				t.Fatalf("escapeODataValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBlank(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "empty string", input: "", want: true},
+		{name: "spaces only", input: "   ", want: true},
+		{name: "tabs only", input: "\t\t", want: true},
+		{name: "mixed whitespace", input: " \t\n ", want: true},
+		{name: "non blank value", input: "eastus", want: false},
+		{name: "value with surrounding whitespace", input: "  eastus  ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBlank(tt.input)
+			if got != tt.want {
+				t.Fatalf("isBlank(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConditionConstructors(t *testing.T) {
+	tests := []struct {
+		name string
+		got  FilterCondition
+		want FilterCondition
+	}{
+		{
+			name: "Region",
+			got:  Region("eastus"),
+			want: FilterCondition{Field: "armRegionName", Value: "eastus"},
+		},
+		{
+			name: "Service",
+			got:  Service("Virtual Machines"),
+			want: FilterCondition{Field: "serviceName", Value: "Virtual Machines"},
+		},
+		{
+			name: "SKU",
+			got:  SKU("Standard_B1s"),
+			want: FilterCondition{Field: "armSkuName", Value: "Standard_B1s"},
+		},
+		{
+			name: "PriceType",
+			got:  PriceType("Consumption"),
+			want: FilterCondition{Field: "priceType", Value: "Consumption"},
+		},
+		{
+			name: "ProductName",
+			got:  ProductName("Virtual Machines BS Series"),
+			want: FilterCondition{Field: "productName", Value: "Virtual Machines BS Series"},
+		},
+		{
+			name: "CurrencyCode",
+			got:  CurrencyCode("USD"),
+			want: FilterCondition{Field: "currencyCode", Value: "USD"},
+		},
+		{
+			name: "Condition",
+			got:  Condition("meterName", "B1s"),
+			want: FilterCondition{Field: "meterName", Value: "B1s"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("%s() = %#v, want %#v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderSingleFieldFilters(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name:  "region",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus") },
+			want:  "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name:  "service",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Service("Virtual Machines") },
+			want:  "priceType eq 'Consumption' and serviceName eq 'Virtual Machines'",
+		},
+		{
+			name:  "sku",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.SKU("Standard_B1s") },
+			want:  "armSkuName eq 'Standard_B1s' and priceType eq 'Consumption'",
+		},
+		{
+			name:  "product name",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.ProductName("Virtual Machines BS Series") },
+			want:  "priceType eq 'Consumption' and productName eq 'Virtual Machines BS Series'",
+		},
+		{
+			name:  "currency code",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.CurrencyCode("USD") },
+			want:  "currencyCode eq 'USD' and priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderMultiFieldFilters(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name: "2 fields",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("eastus").SKU("Standard_B1s")
+			},
+			want: "armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s' and priceType eq 'Consumption'",
+		},
+		{
+			name: "3 fields",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("eastus").Service("Virtual Machines").SKU("Standard_B1s")
+			},
+			want: "armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s' and priceType eq 'Consumption' and serviceName eq 'Virtual Machines'",
+		},
+		{
+			name: "all named fields",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.
+					Region("eastus").
+					SKU("Standard_B1s").
+					Service("Virtual Machines").
+					ProductName("Virtual Machines BS Series").
+					CurrencyCode("USD")
+			},
+			want: "armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s' and currencyCode eq 'USD' and priceType eq 'Consumption' and productName eq 'Virtual Machines BS Series' and serviceName eq 'Virtual Machines'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderTypeDefaultAndOverride(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name:  "default consumption with criteria",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus") },
+			want:  "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name:  "explicit override",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus").Type("Reservation") },
+			want:  "armRegionName eq 'eastus' and priceType eq 'Reservation'",
+		},
+		{
+			name:  "empty type preserves default",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus").Type("") },
+			want:  "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name:  "whitespace type preserves default",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus").Type("  \t ") },
+			want:  "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderFieldMethod(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name: "generic field with named field",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("eastus").Field("meterName", "B1s")
+			},
+			want: "armRegionName eq 'eastus' and meterName eq 'B1s' and priceType eq 'Consumption'",
+		},
+		{
+			name: "empty name omitted",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("eastus").Field("", "B1s")
+			},
+			want: "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name: "empty value omitted",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("eastus").Field("meterName", "")
+			},
+			want: "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name: "same generic field included twice",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Field("meterName", "B2s").Field("meterName", "B1s")
+			},
+			want: "meterName eq 'B1s' and meterName eq 'B2s' and priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderBuildMinimal(t *testing.T) {
+	got := NewFilterBuilder().Build()
+	want := "priceType eq 'Consumption'"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterBuilderLastWriteWins(t *testing.T) {
+	got := NewFilterBuilder().Region("eastus").Region("westus2").Build()
+	want := "armRegionName eq 'westus2' and priceType eq 'Consumption'"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterBuilderOrGroups(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name: "two regions in or group are parenthesized",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Or(Region("eastus"), Region("westus2"))
+			},
+			want: "(armRegionName eq 'eastus' or armRegionName eq 'westus2') and priceType eq 'Consumption'",
+		},
+		{
+			name: "single valid or condition has no parentheses",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Or(Region("eastus"))
+			},
+			want: "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name: "empty conditions inside or are omitted",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Or(Region(""), Condition("   ", "x"), Region("eastus"))
+			},
+			want: "armRegionName eq 'eastus' and priceType eq 'Consumption'",
+		},
+		{
+			name: "all empty or group omitted",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Or(Region(""), Condition("", ""), Service(" \t "))
+			},
+			want: "priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderMixedAndOr(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name: "or group mixed with and condition",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.
+					Or(Region("eastus"), Region("westus2")).
+					Service("Virtual Machines")
+			},
+			want: "(armRegionName eq 'eastus' or armRegionName eq 'westus2') and priceType eq 'Consumption' and serviceName eq 'Virtual Machines'",
+		},
+		{
+			name: "multiple or groups are sorted with and",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.
+					Or(Service("Virtual Machines"), Service("Storage")).
+					Or(Region("eastus"), Region("westus2"))
+			},
+			want: "(armRegionName eq 'eastus' or armRegionName eq 'westus2') and priceType eq 'Consumption' and (serviceName eq 'Storage' or serviceName eq 'Virtual Machines')",
+		},
+		{
+			name: "or group parenthesized when mixed with generic and",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.
+					Field("meterName", "B1s").
+					Or(CurrencyCode("USD"), CurrencyCode("EUR"))
+			},
+			want: "(currencyCode eq 'EUR' or currencyCode eq 'USD') and meterName eq 'B1s' and priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderDeterministicOrdering(t *testing.T) {
+	first := NewFilterBuilder().
+		Region("eastus").
+		Service("Virtual Machines").
+		Or(SKU("Standard_B2s"), SKU("Standard_B1s")).
+		Field("meterName", "B1s").
+		Build()
+
+	second := NewFilterBuilder().
+		Field("meterName", "B1s").
+		Or(SKU("Standard_B1s"), SKU("Standard_B2s")).
+		Service("Virtual Machines").
+		Region("eastus").
+		Build()
+
+	if first != second {
+		t.Fatalf("expected deterministic output, got\nfirst:  %q\nsecond: %q", first, second)
+	}
+
+	got := NewFilterBuilder().
+		Or(Service("Storage"), Service("Virtual Machines")).
+		Or(Region("westus2"), Region("eastus")).
+		Build()
+	want := "(armRegionName eq 'eastus' or armRegionName eq 'westus2') and priceType eq 'Consumption' and (serviceName eq 'Storage' or serviceName eq 'Virtual Machines')"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterBuilderFluentChaining(t *testing.T) {
+	builder := NewFilterBuilder()
+	if got := builder.Region("eastus"); got != builder {
+		t.Fatal("Region() should return the same builder pointer")
+	}
+	if got := builder.Service("Virtual Machines"); got != builder {
+		t.Fatal("Service() should return the same builder pointer")
+	}
+	if got := builder.SKU("Standard_B1s"); got != builder {
+		t.Fatal("SKU() should return the same builder pointer")
+	}
+	if got := builder.ProductName("Virtual Machines BS Series"); got != builder {
+		t.Fatal("ProductName() should return the same builder pointer")
+	}
+	if got := builder.CurrencyCode("USD"); got != builder {
+		t.Fatal("CurrencyCode() should return the same builder pointer")
+	}
+	if got := builder.Field("meterName", "B1s"); got != builder {
+		t.Fatal("Field() should return the same builder pointer")
+	}
+	if got := builder.Or(Region("eastus"), Region("westus2")); got != builder {
+		t.Fatal("Or() should return the same builder pointer")
+	}
+	if got := builder.Type("Reservation"); got != builder {
+		t.Fatal("Type() should return the same builder pointer")
+	}
+
+	got := NewFilterBuilder().
+		Region("eastus").
+		Service("Virtual Machines").
+		SKU("Standard_B1s").
+		Type("Reservation").
+		Build()
+	want := "armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s' and priceType eq 'Reservation' and serviceName eq 'Virtual Machines'"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterBuilderEscapingInOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name:  "single quote in region",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("O'Brien") },
+			want:  "armRegionName eq 'O''Brien' and priceType eq 'Consumption'",
+		},
+		{
+			name:  "multiple quotes in service",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Service("test'service'name") },
+			want:  "priceType eq 'Consumption' and serviceName eq 'test''service''name'",
+		},
+		{
+			name:  "quotes and spaces in product field",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Field("productName", "SQL Server O'Brien Edition") },
+			want:  "priceType eq 'Consumption' and productName eq 'SQL Server O''Brien Edition'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterBuilderEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(*FilterBuilder) *FilterBuilder
+		want  string
+	}{
+		{
+			name:  "whitespace region omitted",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("  ") },
+			want:  "priceType eq 'Consumption'",
+		},
+		{
+			name:  "empty generic field omitted",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Field("", "value") },
+			want:  "priceType eq 'Consumption'",
+		},
+		{
+			name: "all empty values still returns minimal filter",
+			build: func(b *FilterBuilder) *FilterBuilder {
+				return b.Region("").Service(" ").Type("  ").Field("", "").Or(Condition("", ""))
+			},
+			want: "priceType eq 'Consumption'",
+		},
+		{
+			name:  "same named field set twice uses last value",
+			build: func(b *FilterBuilder) *FilterBuilder { return b.Region("eastus").Region("westus2") },
+			want:  "armRegionName eq 'westus2' and priceType eq 'Consumption'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.build(NewFilterBuilder()).Build()
+			if got != tt.want {
+				t.Fatalf("Build() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	builder := NewFilterBuilder().
+		Region("eastus").
+		Service("Virtual Machines").
+		Or(CurrencyCode("USD"), CurrencyCode("EUR"))
+	first := builder.Build()
+	second := builder.Build()
+	if first != second {
+		t.Fatalf("Build() should be idempotent: first=%q second=%q", first, second)
+	}
+}
+
+func BenchmarkBuild(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		filter := NewFilterBuilder().
+			Region("eastus").
+			Service("Virtual Machines").
+			SKU("Standard_B1s").
+			ProductName("Virtual Machines BS Series").
+			CurrencyCode("USD").
+			Field("meterName", "B1s").
+			Field("serviceFamily", "Compute").
+			Field("skuName", "B1s").
+			Or(Region("eastus"), Region("westus2")).
+			Type("Reservation").
+			Build()
+		if filter == "" {
+			b.Fatal("Build() returned empty output")
+		}
+	}
+
+	elapsed := b.Elapsed()
+	avg := elapsed / time.Duration(b.N)
+	if avg >= time.Millisecond {
+		b.Fatalf("average Build() latency %s exceeded 1ms target", avg)
+	}
+}

--- a/specs/009-odata-filter-builder/checklists/requirements.md
+++ b/specs/009-odata-filter-builder/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: OData Filter Query Builder
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- No [NEEDS CLARIFICATION] markers were needed; the issue description provided sufficient detail, and reasonable assumptions were documented in the Assumptions section.
+- Existing codebase already has basic filter building functions (`buildFilterQuery`, `escapeODataString`) which this feature formalizes into a proper builder pattern with defaults.

--- a/specs/009-odata-filter-builder/contracts/filter_builder.go
+++ b/specs/009-odata-filter-builder/contracts/filter_builder.go
@@ -1,0 +1,133 @@
+//go:build ignore
+// +build ignore
+
+// Package contracts defines the API surface for the OData filter builder.
+// This file is a design contract, not compilable production code.
+// It documents the public API that will be implemented in internal/azureclient/filter.go.
+package contracts
+
+// --- Value Types ---
+
+// FilterCondition represents a single OData equality condition.
+// It is an immutable value type created by package-level constructor functions.
+//
+// Example: Region("eastus") creates FilterCondition{Field: "armRegionName", Value: "eastus"}
+type FilterCondition struct {
+	Field string // OData field name (e.g., "armRegionName")
+	Value string // Filter value (e.g., "eastus")
+}
+
+// --- Package-Level Constructors ---
+// These return FilterCondition values for use with FilterBuilder.Or().
+
+// Region creates a condition for armRegionName.
+func Region(value string) FilterCondition
+
+// Service creates a condition for serviceName.
+func Service(value string) FilterCondition
+
+// SKU creates a condition for armSkuName.
+func SKU(value string) FilterCondition
+
+// PriceType creates a condition for priceType.
+func PriceType(value string) FilterCondition
+
+// ProductName creates a condition for productName.
+func ProductName(value string) FilterCondition
+
+// CurrencyCode creates a condition for currencyCode.
+func CurrencyCode(value string) FilterCondition
+
+// Condition creates a condition for an arbitrary OData field.
+func Condition(field, value string) FilterCondition
+
+// --- Builder Type ---
+
+// FilterBuilder constructs OData $filter expressions for the Azure Retail Prices API.
+//
+// The builder provides a fluent/chainable interface where each method returns
+// the builder for method chaining. Criteria are combined with AND logic by default.
+// Use Or() to create parenthesized OR groups.
+//
+// The builder always includes a default priceType filter of "Consumption"
+// unless explicitly overridden via Type().
+//
+// Output is deterministic regardless of the order in which methods are called.
+type FilterBuilder struct {
+	// Internal fields (not exported):
+	// andConditions map[string]string       - named AND conditions (field → value, last-write-wins)
+	// orGroups      [][]FilterCondition     - OR-grouped condition sets
+	// typeValue     *string                 - pricing type override (nil = default "Consumption")
+	// genericFields []FilterCondition       - arbitrary field conditions via Field()
+}
+
+// NewFilterBuilder creates a new FilterBuilder with default settings.
+// The default pricing type is "Consumption" (pay-as-you-go).
+func NewFilterBuilder() *FilterBuilder
+
+// --- Named Convenience Methods (AND conditions, chainable) ---
+
+// Region adds an armRegionName filter criterion (AND logic, last-write-wins).
+func (b *FilterBuilder) Region(value string) *FilterBuilder
+
+// Service adds a serviceName filter criterion (AND logic, last-write-wins).
+func (b *FilterBuilder) Service(value string) *FilterBuilder
+
+// SKU adds an armSkuName filter criterion (AND logic, last-write-wins).
+func (b *FilterBuilder) SKU(value string) *FilterBuilder
+
+// Type sets the priceType filter criterion, overriding the default "Consumption".
+// Empty or whitespace-only values are ignored (default still applies).
+func (b *FilterBuilder) Type(value string) *FilterBuilder
+
+// ProductName adds a productName filter criterion (AND logic, last-write-wins).
+func (b *FilterBuilder) ProductName(value string) *FilterBuilder
+
+// CurrencyCode adds a currencyCode filter criterion (AND logic, last-write-wins).
+func (b *FilterBuilder) CurrencyCode(value string) *FilterBuilder
+
+// --- Generic Field Method (AND condition, chainable) ---
+
+// Field adds an arbitrary OData field filter criterion (AND logic).
+// Both field name and value must be non-empty and non-whitespace.
+// Unlike named methods, generic fields do not use last-write-wins;
+// multiple calls with the same field name are both included.
+func (b *FilterBuilder) Field(name, value string) *FilterBuilder
+
+// --- OR Grouping Method ---
+
+// Or creates a parenthesized OR group from the given conditions.
+// When mixed with AND conditions, OR groups are automatically parenthesized.
+// Empty or whitespace-only conditions within the group are silently omitted.
+// If all conditions are empty, the entire group is omitted.
+//
+// Example:
+//
+//	builder.Or(Region("eastus"), Region("westus2"))
+//	// produces: (armRegionName eq 'eastus' or armRegionName eq 'westus2')
+func (b *FilterBuilder) Or(conditions ...FilterCondition) *FilterBuilder
+
+// --- Build Method ---
+
+// Build produces the OData $filter expression string.
+//
+// The output is deterministic: all parts are sorted alphabetically by their
+// primary field name (first condition's field for OR groups).
+//
+// The default priceType filter ("Consumption") is included unless overridden.
+//
+// Empty/whitespace values are silently omitted. Single quotes in values are
+// escaped per OData conventions (doubled: '').
+//
+// If no criteria are set (all empty), returns the minimal valid filter:
+// "priceType eq 'Consumption'"
+func (b *FilterBuilder) Build() string
+
+// --- Internal Helpers (not exported) ---
+
+// escapeODataValue escapes single quotes in a value per OData v4 conventions.
+// "O'Brien" → "O''Brien"
+// func escapeODataValue(s string) string
+
+// isBlank returns true if s is empty or contains only whitespace.
+// func isBlank(s string) bool

--- a/specs/009-odata-filter-builder/data-model.md
+++ b/specs/009-odata-filter-builder/data-model.md
@@ -1,0 +1,137 @@
+# Data Model: OData Filter Query Builder
+
+**Feature Branch**: `009-odata-filter-builder`
+**Date**: 2026-02-28
+
+## Entities
+
+### FilterCondition
+
+A single OData equality condition pairing a field name with a value.
+
+| Field   | Type     | Description          | Validation           |
+|---------|----------|----------------------|----------------------|
+| `Field` | `string` | OData field name     | Non-empty, non-ws    |
+| `Value` | `string` | Filter value         | Non-empty, non-ws    |
+
+**Purpose**: Immutable value type used as input to `Or()` groups
+and internally by named convenience methods. Created via
+package-level constructor functions.
+
+**Constructors**:
+
+| Function          | Field Mapping   | Example                    |
+|-------------------|-----------------|----------------------------|
+| `Region(v)`       | `armRegionName` | `Region("eastus")`         |
+| `Service(v)`      | `serviceName`   | `Service("VMs")`           |
+| `SKU(v)`          | `armSkuName`    | `SKU("Standard_B1s")`      |
+| `PriceType(v)`    | `priceType`     | `PriceType("Consump.")`    |
+| `ProductName(v)`  | `productName`   | `ProductName("VMs BS")`    |
+| `CurrencyCode(v)` | `currencyCode`  | `CurrencyCode("USD")`      |
+| `Condition(n,v)`  | any             | `Condition("m","B1s")`     |
+
+### FilterBuilder
+
+The composable query constructor. Accumulates filter criteria
+and produces a formatted OData `$filter` expression.
+
+| Field            | Type                  | Default |
+|------------------|-----------------------|---------|
+| `andConditions`  | `map[string]string`   | empty   |
+| `orGroups`       | `[][]FilterCondition` | empty   |
+| `typeValue`      | `*string`             | `nil`   |
+| `genericFields`  | `[]FilterCondition`   | empty   |
+
+**Field Descriptions**:
+
+- `andConditions`: Named AND conditions (field to value,
+  last-write-wins)
+- `orGroups`: OR-grouped condition sets
+- `typeValue`: Pricing type override (nil = default)
+- `genericFields`: Arbitrary field conditions
+
+**State Transitions**:
+
+```text
+                ┌──────────────┐
+                │ Empty Builder │
+                │ (default type │
+                │  "Consumption"│
+                │  pending)     │
+                └──────┬───────┘
+                       │
+        ┌──────────────┼──────────────┐
+        │              │              │
+        ▼              ▼              ▼
+ Named Method     Or() Method    Field() Method
+ (AND condition)  (OR group)     (generic AND)
+        │              │              │
+        ▼              ▼              ▼
+ ┌──────────────────────────────────────┐
+ │         Accumulating Builder          │
+ │  (more methods can be chained)        │
+ └──────────────────┬───────────────────┘
+                    │
+                    ▼ Build()
+ ┌──────────────────────────────────────┐
+ │         Filter String Output          │
+ │  (immutable, deterministic)           │
+ └──────────────────────────────────────┘
+```
+
+**Invariants**:
+
+- `Build()` is idempotent: calling it multiple times produces
+  the same string
+- Named method calls for the same field overwrite
+  (last-write-wins)
+- OR groups are accumulated, never overwritten
+- Empty/whitespace values are silently omitted at `Build()` time
+- Default `priceType eq 'Consumption'` is appended if
+  `typeValue` is nil
+
+### Filter Expression (Output)
+
+The string output of `Build()`. Not a stored entity — it is a
+computed value.
+
+**Format**: OData-compatible `$filter` string.
+
+**Structure**:
+
+```text
+<part1> and <part2> and ... and <partN>
+```
+
+Where each part is either:
+
+- A single AND condition: `fieldName eq 'value'`
+- A parenthesized OR group:
+  `(fieldName eq 'v1' or fieldName eq 'v2')`
+
+**Ordering**: All parts sorted alphabetically by primary field
+name (first condition's field name for OR groups). This ensures
+FR-010 deterministic output.
+
+## Relationships
+
+```text
+FilterCondition ──▶ FilterBuilder.Or()
+FilterCondition ──▶ Region(), Service(), SKU(), etc.
+FilterBuilder   ──▶ Filter Expression (string)
+FilterBuilder   ──▶ buildFilterQuery() in client.go
+PriceQuery      ──▶ FilterBuilder calls
+```
+
+## Validation Rules
+
+| Rule                  | Applies To        | Behavior             |
+|-----------------------|-------------------|----------------------|
+| Empty string value    | All methods       | Silently omitted     |
+| Whitespace-only value | All methods       | Silently omitted     |
+| Empty field name      | `Field()`         | Silently omitted     |
+| Single quote in value | All methods       | Escaped to `''`      |
+| Duplicate named field | Named methods     | Last value wins      |
+| Duplicate generic     | `Field()`         | Both included        |
+| `Type("")`            | `Type()`          | Default still applies|
+| No criteria at all    | `Build()`         | Returns default type |

--- a/specs/009-odata-filter-builder/plan.md
+++ b/specs/009-odata-filter-builder/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: OData Filter Query Builder
+
+**Branch**: `009-odata-filter-builder` | **Date**: 2026-02-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-odata-filter-builder/spec.md`
+
+## Summary
+
+Implement a fluent, chainable `FilterBuilder` type in the `azureclient` package
+that constructs OData-compatible `$filter` expressions for the Azure Retail
+Prices API. The builder provides named methods for 6 common fields (region,
+service, SKU, product, currency, pricing type) plus a generic `Field()` method,
+supports both AND and OR logic with automatic parenthesization, includes a
+default "Consumption" pricing type filter, and properly escapes special
+characters. The existing `buildFilterQuery()` function will be refactored to use
+the builder internally, maintaining backward compatibility with `GetPrices()`.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: None new — pure Go stdlib (`fmt`, `strings`, `sort`)
+**Storage**: N/A — pure data transformation (string builder), no I/O
+**Testing**: `go test` with table-driven tests, `go test -race` (no concurrency
+in builder, but run for CI compliance)
+**Target Platform**: Linux server (gRPC plugin)
+**Project Type**: Single Go module
+**Performance Goals**: Filter construction <1ms for up to 10 criteria (SC-001)
+**Constraints**: No external dependencies, no I/O, no side effects
+**Scale/Scope**: ~200 lines implementation + ~300 lines tests (2 new files)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with `.specify/memory/constitution.md`:
+
+- [x] **Code Quality**: All code passes `golangci-lint`. Error handling: builder
+  silently omits invalid inputs (empty/whitespace) per spec FR-009. Cyclomatic
+  complexity of `Build()` estimated at ~8 (well under 15 limit). New file
+  `filter.go` estimated at ~200 lines (under 300 guideline).
+- [x] **Testing**: TDD workflow — tests written before implementation. Coverage
+  target ≥80% with table-driven tests covering: single-field, multi-field,
+  empty, whitespace, special characters, AND-only, OR-only, mixed AND/OR,
+  default type, type override, generic fields, deterministic ordering. Race
+  detector included in `make test`.
+- [x] **User Experience**: No plugin lifecycle impact (pure data transformation).
+  No logging needed (stateless string builder). Error handling: invalid inputs
+  silently omitted per spec, producing valid output in all cases.
+- [x] **Documentation**: All exported types, functions, and methods will have
+  godoc comments. CLAUDE.md updated with FilterBuilder usage. Docstring coverage
+  ≥80% maintained. Quickstart guide produced as `quickstart.md`.
+- [x] **Performance**: Filter construction is O(n log n) where n = number of
+  conditions (dominated by sort for determinism). SC-001 target: <1ms for 10
+  criteria. No retry/timeout/connection concerns (pure computation).
+- [x] **Architectural Constraints**: Pure string transformation. Does NOT use
+  authenticated Azure APIs, persistent storage, infrastructure mutation, or bulk
+  data embedding.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-odata-filter-builder/
+├── plan.md              # This file
+├── research.md          # Phase 0: OData syntax, API fields, design decisions
+├── data-model.md        # Phase 1: Entity model (FilterCondition, FilterBuilder)
+├── quickstart.md        # Phase 1: Usage examples
+├── contracts/           # Phase 1: Go API contract
+│   └── filter_builder.go
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+internal/azureclient/
+├── filter.go            # NEW: FilterBuilder type, FilterCondition, constructors
+├── filter_test.go       # NEW: Table-driven tests for all filter scenarios
+├── client.go            # MODIFIED: refactor buildFilterQuery() to use FilterBuilder
+├── client_test.go       # MODIFIED: update filter tests for default type
+├── types.go             # UNCHANGED: PriceQuery struct retained for backward compat
+├── errors.go            # UNCHANGED
+├── retry.go             # UNCHANGED
+└── logger.go            # UNCHANGED
+```
+
+**Structure Decision**: Two new files (`filter.go`, `filter_test.go`) added to
+the existing `internal/azureclient/` package. The builder is a pure
+data-transformation component with no dependencies on the HTTP client, retry
+logic, or logging — keeping it in a separate file maintains single
+responsibility while sharing the package namespace for seamless integration.
+
+## Complexity Tracking
+
+No constitution violations. All constraints satisfied within standard limits.
+
+| Aspect       | Assessment                           |
+|--------------|--------------------------------------|
+| Complexity   | `Build()` ~8, other methods ~2       |
+| File size    | `filter.go` ~200, tests ~300 lines   |
+| Dependencies | None (stdlib only)                   |
+| API surface  | 1 type, 1 value, 7 ctors, 9 methods  |

--- a/specs/009-odata-filter-builder/quickstart.md
+++ b/specs/009-odata-filter-builder/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: OData Filter Query Builder
+
+## Import
+
+```go
+import (
+    "github.com/rshade/finfocus-plugin-azure-public/internal/azureclient"
+)
+```
+
+## Basic Usage — AND Filters (Most Common)
+
+Build a filter for Virtual Machines pricing in East US:
+
+```go
+filter := azureclient.NewFilterBuilder().
+    Region("eastus").
+    Service("Virtual Machines").
+    SKU("Standard_B1s").
+    Build()
+// Result (fields sorted alphabetically, default type included):
+// armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s'
+//   and priceType eq 'Consumption'
+//   and serviceName eq 'Virtual Machines'
+```
+
+## Override Default Pricing Type
+
+Query reservation pricing instead of pay-as-you-go:
+
+```go
+filter := azureclient.NewFilterBuilder().
+    Region("eastus").
+    Service("Virtual Machines").
+    Type("Reservation").
+    Build()
+// Result:
+// armRegionName eq 'eastus'
+//   and priceType eq 'Reservation'
+//   and serviceName eq 'Virtual Machines'
+```
+
+## OR Groups — Multiple Regions
+
+Query pricing across multiple regions:
+
+```go
+filter := azureclient.NewFilterBuilder().
+    Or(
+        azureclient.Region("eastus"),
+        azureclient.Region("westus2"),
+    ).
+    Service("Virtual Machines").
+    Build()
+// Result:
+// (armRegionName eq 'eastus' or armRegionName eq 'westus2')
+//   and priceType eq 'Consumption'
+//   and serviceName eq 'Virtual Machines'
+```
+
+## Generic Fields
+
+Filter on any OData field not covered by named methods:
+
+```go
+filter := azureclient.NewFilterBuilder().
+    Region("eastus").
+    Field("meterName", "B1s Low Priority").
+    Build()
+// Result:
+// armRegionName eq 'eastus'
+//   and meterName eq 'B1s Low Priority'
+//   and priceType eq 'Consumption'
+```
+
+## Special Characters — Automatic Escaping
+
+Values with single quotes are escaped per OData conventions:
+
+```go
+filter := azureclient.NewFilterBuilder().
+    Field("productName", "SQL Server O'Brien Edition").
+    Build()
+// Result:
+// priceType eq 'Consumption'
+//   and productName eq 'SQL Server O''Brien Edition'
+// Single quotes are doubled: O'Brien → O''Brien
+```
+
+## Minimal Filter — No Criteria
+
+When no criteria are set, returns only the default pricing type:
+
+```go
+filter := azureclient.NewFilterBuilder().Build()
+// Result: "priceType eq 'Consumption'"
+```
+
+## Package-Level Constructors
+
+Use package-level functions to create `FilterCondition` values
+for `Or()`:
+
+| Function          | OData Field     | Example                   |
+|-------------------|-----------------|---------------------------|
+| `Region(v)`       | `armRegionName` | `Region("eastus")`        |
+| `Service(v)`      | `serviceName`   | `Service("VMs")`          |
+| `SKU(v)`          | `armSkuName`    | `SKU("Standard_B1s")`     |
+| `PriceType(v)`    | `priceType`     | `PriceType("Res.")`       |
+| `ProductName(v)`  | `productName`   | `ProductName("VMs BS")`   |
+| `CurrencyCode(v)` | `currencyCode`  | `CurrencyCode("USD")`     |
+| `Condition(n,v)`  | any             | `Condition("m","B")`      |
+
+## Integration with Existing HTTP Client
+
+The existing `GetPrices(PriceQuery)` method uses the builder
+internally. No changes needed for current callers:
+
+```go
+query := azureclient.PriceQuery{
+    ArmRegionName: "eastus",
+    ArmSkuName:    "Standard_B1s",
+}
+prices, err := client.GetPrices(ctx, query)
+// Internally uses FilterBuilder now.
+// Includes default priceType eq 'Consumption' filter.
+```

--- a/specs/009-odata-filter-builder/research.md
+++ b/specs/009-odata-filter-builder/research.md
@@ -1,0 +1,233 @@
+# Research: OData Filter Query Builder
+
+**Feature Branch**: `009-odata-filter-builder`
+**Date**: 2026-02-28
+
+## Research Tasks
+
+### RT-001: OData v4 Filter Syntax Conventions
+
+**Decision**: Use standard OData v4 `$filter` expression syntax with lowercase
+operators (`and`, `or`, `not`) and single-quoted string values.
+
+**Rationale**: The Azure Retail Prices API uses OData v4, which is the standard
+for Microsoft REST APIs. The syntax is well-documented and widely supported.
+
+**Key Rules**:
+
+- String values are delimited by single quotes: `field eq 'value'`
+- Single quotes within values are escaped by doubling: `O'Brien` →
+  `'O''Brien'`
+- Logical operators are lowercase: `and`, `or`, `not`
+- Comparison operators: `eq`, `ne`, `gt`, `lt`, `ge`, `le`
+- Operator precedence (highest to lowest): `not` > comparisons > `and` > `or`
+- Parentheses override precedence: `(a or b) and c`
+- Field names are unquoted and case-sensitive (API version 2023-01-01-preview+)
+
+**Alternatives Considered**:
+
+- Custom query syntax → Rejected: OData is the API standard; inventing syntax
+  adds complexity without benefit
+- URL-encoded key-value pairs → Rejected: Doesn't support complex boolean logic
+
+### RT-002: Azure Retail Prices API Filter Fields
+
+**Decision**: Support all documented `$filter` fields plus `currencyCode` for
+backward compatibility.
+
+**Rationale**: The API documents specific fields as filterable. The builder
+should provide named methods for the most common ones and a generic `Field()`
+method for the rest.
+
+**Supported `$filter` Fields** (from Microsoft documentation):
+
+| Field            | Named Method       | Notes                |
+|------------------|--------------------|----------------------|
+| `armRegionName`  | `Region()`         | ARM region ID        |
+| `serviceName`    | `Service()`        | Service name         |
+| `armSkuName`     | `SKU()`            | ARM SKU name         |
+| `productName`    | `ProductName()`    | Full product name    |
+| `priceType`      | `Type()`           | Pricing type         |
+| `currencyCode`   | `CurrencyCode()`   | See note below       |
+| Any other        | `Field(name, val)` | Generic method       |
+
+**CurrencyCode Note**: The Azure documentation specifies `currencyCode` as a URL
+query parameter (`?currencyCode=EUR`), not a `$filter` field. However, the
+existing codebase uses it within the filter expression, and integration tests
+pass. The builder will support it as a filter criterion for backward
+compatibility. The HTTP client layer can optionally extract it to a query
+parameter in a future iteration.
+
+**Additional filterable fields** (available via `Field()` method): `Location`,
+`meterId`, `meterName`, `productid`, `skuId`, `skuName`, `serviceId`,
+`serviceFamily`.
+
+**Alternatives Considered**:
+
+- Only support the 4 fields from the original issue → Rejected: spec clarified
+  all 6 named methods plus generic Field()
+- Remove currencyCode from filter → Rejected: breaks backward compatibility with
+  existing `PriceQuery` behavior
+
+### RT-003: Default Pricing Type ("Consumption")
+
+**Decision**: The builder will always include `priceType eq 'Consumption'` unless
+explicitly overridden via `Type()`.
+
+**Rationale**: Without a default pricing type, queries return mixed results
+including reservation and dev/test pricing, leading to incorrect cost estimates.
+"Consumption" represents standard pay-as-you-go pricing, which is the most
+commonly needed tier.
+
+**Valid priceType values**:
+
+- `Consumption` - pay-as-you-go (default)
+- `Reservation` - reserved instances
+- `DevTestConsumption` - dev/test pricing
+
+**Behavioral Change**: The existing `buildFilterQuery()` does NOT add a default
+type filter. Adding it changes the result set returned by `GetPrices()`. This is
+intentional per FR-003 and narrows results to only pay-as-you-go pricing.
+
+**Alternatives Considered**:
+
+- No default type → Rejected: spec requires it (FR-003)
+- Default to empty (no type filter) → Rejected: mixed results cause incorrect
+  cost estimates
+
+### RT-004: AND/OR Logic and Grouping Design
+
+**Decision**: Use a dual-API approach: named methods add individual AND
+conditions; `Or()` method creates parenthesized OR groups from `FilterCondition`
+values.
+
+**Rationale**: The most common case (AND-only) should be simple. OR is less
+common and benefits from explicit grouping semantics. Package-level constructor
+functions (`Region()`, `Service()`, etc.) return `FilterCondition` values for use
+with `Or()`.
+
+**API Design**:
+
+```go
+// Simple AND (most common):
+filter := azureclient.NewFilterBuilder().
+    Region("eastus").
+    Service("Virtual Machines").
+    Build()
+
+// OR group with AND:
+filter := azureclient.NewFilterBuilder().
+    Or(azureclient.Region("eastus"), azureclient.Region("westus2")).
+    Service("Virtual Machines").
+    Build()
+// → "(armRegionName eq 'eastus' or armRegionName eq 'westus2') and ..."
+```
+
+**Precedence Handling**: Since `and` binds tighter than `or` in OData, OR groups
+are always parenthesized when the final expression contains both AND and OR. This
+prevents ambiguity regardless of the number of conditions.
+
+**Alternatives Considered**:
+
+- Single `Add(operator, conditions...)` method → Rejected: less readable,
+  violates fluent API requirement
+- Separate `AndBuilder`/`OrBuilder` types → Rejected: over-engineered for the
+  scope
+- Callback-based grouping (`OrGroup(func(b))`) → Rejected: more complex API,
+  harder to compose
+
+### RT-005: Deterministic Output Ordering
+
+**Decision**: Sort all top-level filter parts alphabetically by their primary
+field name. For OR groups, the primary field is the first condition's field name.
+
+**Rationale**: Alphabetical sorting by field name is simple, predictable, and
+independent of call order. Named Azure fields sort naturally:
+`armRegionName` < `armSkuName` < `currencyCode` < `priceType` < `productName` <
+`serviceName`.
+
+**Alternatives Considered**:
+
+- Canonical fixed order (region, service, sku, ...) → Rejected: harder to extend
+  when generic fields are added
+- Insertion order → Rejected: violates FR-010 (must be independent of call order)
+
+### RT-006: Empty and Whitespace Value Handling
+
+**Decision**: Empty strings and whitespace-only strings are silently omitted from
+the filter. No error is returned.
+
+**Rationale**: Per FR-009, empty/whitespace values should not produce invalid
+clauses. Silent omission is the least surprising behavior for a builder pattern.
+
+**Edge Cases**:
+
+- `Region("")` → omitted
+- `Region("   ")` → omitted (whitespace-only)
+- `Type("")` → omitted, default "Consumption" still applies
+- `Type("   ")` → omitted, default "Consumption" still applies
+- `Field("", "value")` → omitted (empty field name)
+- `Field("name", "")` → omitted (empty value)
+
+### RT-007: Same-Field Override Behavior
+
+**Decision**: For named methods (AND conditions), the last value wins. For OR
+groups, all conditions are preserved.
+
+**Rationale**: Per the spec edge cases: "The last value wins (override
+behavior)." This applies to named method calls. OR groups represent explicit
+multi-value intent and should not be deduplicated.
+
+**Example**:
+
+```go
+// Last value wins for named methods:
+builder.Region("eastus").Region("westus2").Build()
+// → "armRegionName eq 'westus2' and priceType eq 'Consumption'"
+
+// OR groups are preserved:
+builder.Or(Region("eastus"), Region("westus2")).Build()
+// → "(armRegionName eq 'eastus' or armRegionName eq 'westus2')
+//     and priceType eq 'Consumption'"
+```
+
+**No deduplication** between named conditions and OR groups (per spec: "The
+caller is responsible for avoiding conflicts").
+
+### RT-008: Integration with Existing HTTP Client
+
+**Decision**: Refactor `buildFilterQuery()` in `client.go` to use
+`FilterBuilder` internally. Keep `GetPrices(PriceQuery)` signature unchanged.
+
+**Rationale**: This provides backward compatibility while adopting the new
+builder. The `FilterBuilder` is also exported for direct use by callers who need
+more control (OR logic, generic fields).
+
+**Refactored `buildFilterQuery`**:
+
+```go
+func buildFilterQuery(query PriceQuery) string {
+    return NewFilterBuilder().
+        Region(query.ArmRegionName).
+        Service(query.ServiceName).
+        SKU(query.ArmSkuName).
+        ProductName(query.ProductName).
+        CurrencyCode(query.CurrencyCode).
+        Build()
+}
+```
+
+**Note**: This adds the default `priceType eq 'Consumption'` to all queries made
+via `GetPrices()`, which is the intended behavioral change per FR-003.
+
+**Alternatives Considered**:
+
+- New `GetPricesWithFilter(*FilterBuilder)` method → Deferred: can be added in a
+  future feature without changing the builder
+- Replace `PriceQuery` with `FilterBuilder` in `GetPrices` → Rejected: breaking
+  API change
+
+## Unresolved Items
+
+None. All NEEDS CLARIFICATION items have been resolved through spec analysis
+and API documentation review.

--- a/specs/009-odata-filter-builder/spec.md
+++ b/specs/009-odata-filter-builder/spec.md
@@ -1,0 +1,224 @@
+# Feature Specification: OData Filter Query Builder
+
+**Feature Branch**: `009-odata-filter-builder`
+**Created**: 2026-02-28
+**Status**: Draft
+**Input**: GitHub Issue #9 - Implement OData filter query builder
+
+## Clarifications
+
+### Session 2026-02-28
+
+- Q: Should the builder support OR logic in addition to AND? → A: Yes,
+  support both AND and OR with explicit method selection.
+- Q: Should the builder include ProductName and CurrencyCode fields
+  (from existing PriceQuery) beyond the 4 in the issue? → A: Yes,
+  include all 6 named methods (Region, Service, SKU, Type, ProductName,
+  CurrencyCode) plus a generic Field(name, value) for arbitrary OData
+  fields.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build Simple Price Filters (Priority: P1)
+
+As cost estimation logic, I need to construct filter expressions that
+target specific cloud resources by region, service, SKU, product name,
+currency code, and pricing type so that the pricing API returns only
+relevant results. The builder should provide named methods for common
+fields plus a generic method for arbitrary OData fields, offering a
+clear, composable interface without requiring knowledge of the
+underlying query syntax.
+
+**Why this priority**: This is the core use case. Without the ability to filter by region, service, and SKU, the system cannot retrieve targeted pricing data, making cost estimation impossible.
+
+**Independent Test**: Can be fully tested by constructing a filter with region and SKU criteria and verifying the output matches the expected query syntax. Delivers the ability to query for specific VM pricing in a specific region.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new filter builder, **When** region "eastus" and SKU "Standard_B1s" are specified, **Then** the output contains both criteria plus the default Consumption pricing type, all joined with AND logic
+2. **Given** a new filter builder, **When** only region "westus2" is specified, **Then** the output contains only the region criterion plus the default pricing type filter
+3. **Given** a new filter builder, **When** region, service "Virtual
+   Machines", and SKU "B1s" are all specified, **Then** the output
+   contains all three criteria plus the default Consumption pricing
+   type, combined correctly with AND logic
+4. **Given** a new filter builder, **When** a generic field
+   "meterName" with value "B1s Low Priority" is specified alongside
+   region "eastus", **Then** the output includes both the named region
+   criterion and the arbitrary field criterion
+
+---
+
+### User Story 2 - Default Pay-As-You-Go Pricing Type (Priority: P1)
+
+As the HTTP client, I need every filter to include a default pricing type of "Consumption" (pay-as-you-go) unless explicitly overridden, so that queries return the most commonly needed pricing tier without requiring callers to remember this filter.
+
+**Why this priority**: Without a default pricing type, queries may return mixed results including reservation and dev/test pricing, leading to incorrect cost estimates. This is equally critical as basic filtering.
+
+**Independent Test**: Can be tested by building a filter with no explicit type and verifying the output includes the Consumption type criterion. Also testable by overriding the type and confirming the override takes effect.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new filter builder with region "eastus", **When** no pricing type is explicitly set, **Then** the output includes both the region and the default Consumption type filter
+2. **Given** a new filter builder, **When** pricing type is explicitly set to "Reservation", **Then** the output uses "Reservation" instead of the default "Consumption"
+3. **Given** a new filter builder with no criteria set, **When** the filter is built, **Then** the output is a minimal valid filter containing only the default Consumption type
+
+---
+
+### User Story 3 - Fluent API for Complex Filters (Priority: P2)
+
+As a developer, I want a chainable, fluent interface for building
+filters with explicit AND/OR logic selection so that complex
+multi-criteria queries are readable and easy to construct without
+manual string concatenation.
+
+**Why this priority**: Developer ergonomics improve adoption and reduce
+bugs. While the system works with a basic interface, a fluent API with
+both AND and OR support reduces mistakes from manual filter assembly
+and enables more expressive queries (e.g., querying multiple regions
+or multiple SKUs in a single request).
+
+**Independent Test**: Can be tested by chaining multiple filter methods
+with both AND and OR operators in a single expression and verifying
+the resulting output is correct and readable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new filter builder, **When** Region, Service, SKU, and
+   Type methods are chained together with AND logic, **Then** a
+   correctly formatted filter string is produced with all four
+   criteria joined by AND
+2. **Given** a new filter builder, **When** methods are called in any
+   order, **Then** the output is deterministic and independent of call
+   order
+3. **Given** a new filter builder, **When** two region criteria are
+   combined with OR logic, **Then** the output produces a filter with
+   the two regions joined by OR and properly grouped
+4. **Given** a new filter builder, **When** AND and OR logic are mixed,
+   **Then** OR-grouped criteria are parenthesized to preserve correct
+   operator precedence
+
+---
+
+### User Story 4 - Safe Value Handling (Priority: P2)
+
+As a test writer and security-conscious developer, I want filter values to be properly escaped so that special characters in input (such as quotes or apostrophes) do not corrupt the query syntax or cause unexpected behavior.
+
+**Why this priority**: Malformed queries could return wrong data or cause API errors. Proper escaping ensures reliability and prevents query injection.
+
+**Independent Test**: Can be tested by constructing filters with values containing special characters (single quotes, spaces, Unicode) and verifying the output is syntactically valid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a filter builder, **When** a value containing a single quote (e.g., "O'Brien") is provided, **Then** the quote is properly escaped in the output
+2. **Given** a filter builder, **When** a value containing spaces (e.g., "Virtual Machines") is provided, **Then** the value is preserved correctly in the output
+3. **Given** a filter builder, **When** an empty string is provided for a field, **Then** that field is omitted from the filter rather than producing an invalid empty clause
+
+---
+
+### Edge Cases
+
+- What happens when all filter fields are empty? The builder returns the minimal valid filter (default Consumption type only).
+- What happens when a value contains single quotes? Single quotes are escaped per OData conventions (doubled: `''`).
+- What happens when the same field is set multiple times? The last value wins (override behavior).
+- What happens when a value contains only whitespace? Whitespace-only values are treated as empty and the field is omitted.
+- What happens when AND and OR are mixed without explicit grouping? OR-joined criteria are automatically parenthesized to ensure correct OData operator precedence (AND binds tighter than OR in OData, but explicit grouping avoids ambiguity).
+- What happens when a generic field name is empty? The field is omitted from the filter (same as empty value behavior).
+- What happens when a generic field duplicates a named field (e.g., Field("armRegionName", "eastus") alongside Region("westus2"))? Both are included; the builder does not deduplicate across named and generic fields. The caller is responsible for avoiding conflicts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a filter builder that constructs OData-compatible filter expressions from individual search criteria
+- **FR-002**: System MUST support filtering by region name, service
+  name, SKU name, product name, and currency code as individual
+  named composable AND criteria with last-write-wins semantics.
+  Pricing type filtering is governed separately by FR-003 and FR-004
+  due to its default-value behavior.
+- **FR-002a**: System MUST provide a generic field method that accepts
+  an arbitrary field name and value, enabling filters on any OData
+  field not covered by the named methods
+- **FR-003**: System MUST include a default pricing type filter of "Consumption" (pay-as-you-go) when no explicit type is specified
+- **FR-004**: System MUST allow the default pricing type to be overridden by explicitly setting a different type value
+- **FR-005**: System MUST support combining criteria using both AND and OR logic with explicit method selection for each operator
+- **FR-005a**: System MUST default to AND logic when combining filter criteria
+- **FR-005b**: System MUST support OR logic for combining alternative values (e.g., region "eastus" OR region "westus2")
+- **FR-005c**: System MUST automatically parenthesize OR-grouped criteria when mixed with AND to preserve correct operator precedence
+- **FR-006**: System MUST properly escape special characters in filter values (specifically single quotes, per OData v4 conventions)
+- **FR-007**: System MUST return a minimal valid filter (containing only the default type) when no other criteria are specified
+- **FR-008**: System MUST provide a fluent/chainable interface where each filter method returns the builder for method chaining
+- **FR-009**: System MUST omit fields with empty or whitespace-only values from the filter expression rather than producing invalid clauses
+- **FR-010**: System MUST produce deterministic output regardless of the order in which filter methods are called
+
+### Key Entities
+
+- **FilterBuilder**: A composable query constructor that accumulates
+  filter criteria with explicit AND/OR logic and produces a formatted
+  filter expression. Named attributes: region, service, SKU, pricing
+  type, product name, and currency code. Also supports arbitrary
+  field/value pairs via a generic method. Tracks the logical operator
+  (AND/OR) binding each group.
+- **Filter Expression**: The string output of the builder, formatted as
+  an OData-compatible query filter with properly escaped values,
+  AND/OR-joined criteria, and parenthesized grouping where needed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All filter construction operations complete in under 1 millisecond for up to 10 combined criteria
+- **SC-002**: 100% of filter expressions produced by the builder are syntactically valid OData filter strings
+- **SC-003**: Test coverage for the filter builder reaches at least
+  80%, covering single-field, multi-field, empty, special-character,
+  AND-only, OR-only, and mixed AND/OR scenarios
+- **SC-004**: Developers can construct a complete multi-criteria filter in a single chained expression without intermediate variables
+- **SC-005**: Zero query syntax errors caused by unescaped special characters in filter values
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations (>=80% for business logic)
+- [x] Error handling strategy is defined (no silent failures)
+- [x] Code complexity is considered (functions <15 cyclomatic complexity)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then format)
+- [x] Integration test needs identified (external API interactions)
+- [x] Performance test criteria specified (if applicable)
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable
+- [x] Response time expectations defined (e.g., cache hits <10ms, API calls <2s p95)
+- [x] Observability requirements specified (logging, metrics)
+
+### Documentation
+
+- [x] README.md updates identified (if user-facing changes)
+- [x] API documentation needs outlined (godoc comments, contracts)
+- [x] Docstring coverage >=80% maintained (all exported symbols documented)
+- [x] Examples/quickstart guide planned (if new capability)
+
+### Performance & Reliability
+
+- [x] Performance targets specified (response times, throughput)
+- [x] Reliability requirements defined (retry logic, error handling)
+- [x] Resource constraints considered (memory, connections, cache TTL)
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The Azure Retail Prices API uses OData v4 filter syntax where values are enclosed in single quotes and criteria are joined with ` and `.
+- "Consumption" is the correct type value for pay-as-you-go pricing in the Azure Retail Prices API.
+- The existing HTTP client will be updated to use the new filter builder instead of manually constructing filter strings.
+- The filter builder is a pure data transformation (input criteria to output string) with no I/O, network, or side effects.
+- Filter field ordering in the output does not affect API query results (field order is deterministic for testability, not for API correctness).
+- **Behavioral change**: After integration (Phase 6), all queries via `GetPrices()` will include `priceType eq 'Consumption'` by default. The existing `buildFilterQuery()` does not include any pricing type filter. This is an intentional improvement — without a type filter, queries return mixed Consumption/Reservation/DevTest results, which can produce incorrect cost estimates. Existing tests must be updated to expect the new default filter.

--- a/specs/009-odata-filter-builder/tasks.md
+++ b/specs/009-odata-filter-builder/tasks.md
@@ -1,0 +1,418 @@
+# Tasks: OData Filter Query Builder
+
+**Input**: Design documents from `/specs/009-odata-filter-builder/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/filter_builder.go
+
+**Tests**: Included per constitution (TDD is NON-NEGOTIABLE).
+Tests MUST be written FIRST and FAIL before implementation.
+
+**Organization**: Tasks grouped by user story. US1+US2 are
+combined (both P1, tightly coupled — US1 acceptance scenarios
+reference default type from US2).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no deps)
+- **[Story]**: User story label (US1, US2, US3, US4)
+- All paths relative to repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create new files for the FilterBuilder
+
+- [X] T001 Create `internal/azureclient/filter.go` with
+  package `azureclient` declaration, package-level doc comment,
+  and stdlib imports (`fmt`, `sort`, `strings`)
+- [X] T002 Create `internal/azureclient/filter_test.go` with
+  package `azureclient` declaration and `testing` import
+
+**Checkpoint**: Two empty files exist, `make build` passes
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types and helpers needed by ALL user stories
+
+**CRITICAL**: No user story work can begin until this phase
+is complete
+
+### Tests for Foundational
+
+> **NOTE: Write these tests FIRST, ensure they FAIL**
+
+- [X] T003 [P] Write table-driven tests for `escapeODataValue`
+  in `internal/azureclient/filter_test.go` — cases: empty
+  string, no quotes, single quote, multiple quotes, consecutive
+  quotes, value with spaces
+- [X] T004 [P] Write table-driven tests for `isBlank` in
+  `internal/azureclient/filter_test.go` — cases: empty string,
+  spaces only, tabs only, mixed whitespace, non-blank value,
+  value with leading/trailing spaces
+- [X] T005 [P] Write table-driven tests for package-level
+  constructors (`Region`, `Service`, `SKU`, `PriceType`,
+  `ProductName`, `CurrencyCode`, `Condition`) in
+  `internal/azureclient/filter_test.go` — verify each returns
+  correct `FilterCondition` with expected Field and Value
+
+### Implementation for Foundational
+
+- [X] T006 Implement `FilterCondition` exported struct type
+  with `Field` and `Value` string fields, and all 7
+  package-level constructor functions (`Region`, `Service`,
+  `SKU`, `PriceType`, `ProductName`, `CurrencyCode`, `Condition`) in
+  `internal/azureclient/filter.go`
+- [X] T007 Implement `escapeODataValue` (doubles single quotes)
+  and `isBlank` (empty or whitespace-only check) unexported
+  helpers in `internal/azureclient/filter.go`
+- [X] T008 Verify foundational tests pass with `make test`
+
+**Checkpoint**: FilterCondition type, constructors, and helpers
+all tested and working
+
+---
+
+## Phase 3: US1 + US2 — Simple Filters + Default Type (P1)
+
+**Goal**: Construct AND-joined OData filter expressions from
+named fields and generic fields, with automatic default
+`priceType eq 'Consumption'` included unless overridden
+
+**Independent Test**: Build a filter with Region("eastus") and
+SKU("Standard_B1s"), verify output is
+`armRegionName eq 'eastus' and armSkuName eq 'Standard_B1s'
+and priceType eq 'Consumption'`
+
+### Tests for US1 + US2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL**
+
+- [X] T009 [P] [US1] Write table-driven tests for single-field
+  AND filters in `internal/azureclient/filter_test.go` — test
+  each named method individually (Region, Service, SKU,
+  ProductName, CurrencyCode) produces correct output with
+  default type appended
+- [X] T010 [P] [US1] Write table-driven tests for multi-field
+  AND filters in `internal/azureclient/filter_test.go` — test
+  combinations of 2, 3, and all 5 named fields; verify all
+  criteria present, AND-joined, alphabetically sorted
+- [X] T011 [P] [US2] Write table-driven tests for default
+  Consumption type in `internal/azureclient/filter_test.go` —
+  test: no type set produces default, explicit Type("Reservation")
+  overrides, Type("") preserves default, Type("  ") preserves
+  default
+- [X] T012 [P] [US1] Write table-driven tests for generic
+  Field() method in `internal/azureclient/filter_test.go` —
+  test: Field("meterName","B1s") alongside Region, Field with
+  empty name omitted, Field with empty value omitted, multiple
+  Field calls for same name both included
+- [X] T013 [P] [US1] Write test for empty/minimal build in
+  `internal/azureclient/filter_test.go` — test:
+  NewFilterBuilder().Build() returns
+  `priceType eq 'Consumption'`
+- [X] T014 [P] [US1] Write test for last-write-wins behavior
+  in `internal/azureclient/filter_test.go` — test:
+  Region("eastus").Region("westus2") produces only westus2
+
+### Implementation for US1 + US2
+
+- [X] T015 [US1] Implement `FilterBuilder` struct with
+  unexported fields (`andConditions`, `orGroups`, `typeValue`,
+  `genericFields`) and `NewFilterBuilder()` constructor in
+  `internal/azureclient/filter.go`
+- [X] T016 [US1] Implement named chainable methods (`Region`,
+  `Service`, `SKU`, `ProductName`, `CurrencyCode`) that store
+  AND conditions with last-write-wins in
+  `internal/azureclient/filter.go`
+- [X] T017 [US2] Implement `Type()` method that sets
+  `typeValue` override (skip if blank) in
+  `internal/azureclient/filter.go`
+- [X] T018 [US1] Implement `Field()` method that appends to
+  `genericFields` slice (skip if name or value blank) in
+  `internal/azureclient/filter.go`
+- [X] T019 [US1] Implement `Build()` method for AND-only logic:
+  collect andConditions + genericFields + default/override
+  priceType, escape values, sort alphabetically by field name,
+  join with ` and ` in `internal/azureclient/filter.go`
+- [X] T020 [US1] Verify all US1+US2 tests pass with `make test`
+
+**Checkpoint**: Simple AND filters with default type work.
+All 4 US1 and 3 US2 acceptance scenarios pass.
+
+---
+
+## Phase 4: US3 — Fluent API with OR Logic (P2)
+
+**Goal**: Support OR-grouped conditions with automatic
+parenthesization, chainable in a single expression, with
+deterministic output regardless of call order
+
+**Independent Test**: Build
+`Or(Region("eastus"),Region("westus2")).Service("VMs").Build()`
+and verify output is
+`(armRegionName eq 'eastus' or armRegionName eq 'westus2')
+and priceType eq 'Consumption' and serviceName eq 'VMs'`
+
+### Tests for US3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL**
+
+- [X] T021 [P] [US3] Write table-driven tests for `Or()` groups
+  in `internal/azureclient/filter_test.go` — test: two regions
+  OR-joined, OR group parenthesized, single-condition OR (no
+  parens needed), empty conditions in OR omitted, all-empty OR
+  group omitted entirely
+- [X] T022 [P] [US3] Write table-driven tests for mixed AND/OR
+  in `internal/azureclient/filter_test.go` — test: OR group
+  with AND conditions, multiple OR groups, OR groups
+  parenthesized correctly when mixed with AND
+- [X] T023 [P] [US3] Write tests for deterministic ordering in
+  `internal/azureclient/filter_test.go` — test: same methods
+  called in different orders produce identical output, OR group
+  sorted by first condition's field name
+- [X] T024 [P] [US3] Write tests for fluent method chaining in
+  `internal/azureclient/filter_test.go` — test: full chain
+  `NewFilterBuilder().Region().Service().SKU().Type().Build()`
+  in single expression, verify return type is `*FilterBuilder`
+  for all methods
+
+### Implementation for US3
+
+- [X] T025 [US3] Implement `Or()` method that appends valid
+  (non-blank) conditions to `orGroups` slice in
+  `internal/azureclient/filter.go`
+- [X] T026 [US3] Update `Build()` to render OR groups as
+  parenthesized expressions joined by ` or `, include in
+  top-level parts sorted by primary field name, and join all
+  parts with ` and ` in `internal/azureclient/filter.go`
+- [X] T027 [US3] Verify all US3 tests pass with `make test`
+
+**Checkpoint**: Fluent chaining with AND/OR works. All 4 US3
+acceptance scenarios pass.
+
+---
+
+## Phase 5: US4 — Safe Value Handling (P2)
+
+**Goal**: Ensure special characters, empty values, and edge
+cases are handled correctly in filter output
+
+**Independent Test**: Build a filter with value `O'Brien` and
+verify output contains `'O''Brien'` (doubled single quote)
+
+### Tests for US4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL**
+
+- [X] T028 [P] [US4] Write table-driven tests for single quote
+  escaping in full filter output in
+  `internal/azureclient/filter_test.go` — test:
+  Region("O'Brien") produces `armRegionName eq 'O''Brien'`,
+  multiple quotes, value with both quotes and spaces
+- [X] T029 [P] [US4] Write table-driven tests for edge cases
+  in `internal/azureclient/filter_test.go` — test:
+  whitespace-only Region("  ") omitted, empty string
+  Field("","val") omitted, all fields empty returns minimal
+  filter, same field set twice last-write-wins, Build()
+  idempotent (call twice, same result)
+
+### Implementation for US4
+
+- [X] T030 [US4] Review and verify that `Build()` in
+  `internal/azureclient/filter.go` calls `escapeODataValue`
+  on all values and `isBlank` to omit empty/whitespace — add
+  any missing edge case handling
+- [X] T031 [US4] Verify all US4 tests pass with `make test`
+
+**Checkpoint**: All edge cases handled. All 3 US4 acceptance
+scenarios pass.
+
+---
+
+## Phase 6: Client Integration
+
+**Purpose**: Refactor existing HTTP client to use FilterBuilder
+
+- [X] T032 Refactor `buildFilterQuery()` in
+  `internal/azureclient/client.go` to use `NewFilterBuilder()`
+  with `Region()`, `Service()`, `SKU()`, `ProductName()`,
+  `CurrencyCode()` from the `PriceQuery` struct fields, then
+  call `Build()` — delete the old manual filter construction
+  and the now-redundant local `escapeODataString` function
+- [X] T033 Update existing filter tests in
+  `internal/azureclient/client_test.go` to account for the new
+  default `priceType eq 'Consumption'` that is now included in
+  all filter output — update expected strings and assertions
+- [X] T034 Run full test suite with `make test` to verify no
+  regressions in client, retry, or integration tests
+
+**Checkpoint**: Existing `GetPrices()` works with FilterBuilder
+internally. No API changes, no regressions.
+
+---
+
+## Phase 7: Polish and Cross-Cutting Concerns
+
+**Purpose**: Constitution compliance and documentation
+
+### Constitution Compliance Tasks
+
+- [X] T035 [P] Run `make lint` and fix all linting issues in
+  `internal/azureclient/filter.go` and
+  `internal/azureclient/filter_test.go`
+- [X] T036 [P] Run `go test -race ./internal/azureclient/...`
+  to verify thread safety
+- [X] T037 [P] Verify test coverage is at least 80% for
+  `internal/azureclient/filter.go` with
+  `go test -cover ./internal/azureclient/...`
+- [X] T038 [P] Verify all exported types, functions, and
+  methods in `internal/azureclient/filter.go` have godoc
+  comments — ensure docstring coverage is at least 80%
+- [X] T039 [P] Verify architectural constraints: no
+  authenticated Azure APIs, no persistent storage, no
+  infrastructure mutation, no bulk data embedding
+- [X] T042 [P] Write a `BenchmarkBuild` function in
+  `internal/azureclient/filter_test.go` that exercises
+  `NewFilterBuilder()` with 10 criteria (5 named + 3 generic +
+  1 Or group + 1 Type override), calls `Build()`, and validates
+  SC-001 performance target (<1ms) using `b.Elapsed()`
+
+### Documentation Tasks
+
+- [X] T040 Update CLAUDE.md `## Azure Client` section with
+  FilterBuilder usage examples showing `NewFilterBuilder()`,
+  named methods, `Or()`, `Field()`, and `Build()`
+- [X] T041 Validate `specs/009-odata-filter-builder/quickstart.md`
+  examples match actual `Build()` output — run each example
+  mentally or as a test
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+```text
+Phase 1 (Setup) ─────────▶ Phase 2 (Foundational)
+                                    │
+                                    ▼
+                           Phase 3 (US1+US2)
+                                    │
+                            ┌───────┴───────┐
+                            ▼               ▼
+                     Phase 4 (US3)   Phase 5 (US4)
+                            │               │
+                            └───────┬───────┘
+                                    ▼
+                           Phase 6 (Integration)
+                                    │
+                                    ▼
+                           Phase 7 (Polish)
+```
+
+### User Story Dependencies
+
+- **US1+US2 (P1)**: Depends on Foundational (Phase 2).
+  No dependencies on other stories.
+- **US3 (P2)**: Depends on US1+US2 (needs FilterBuilder
+  struct and Build() to exist). Adds Or() and updates Build().
+- **US4 (P2)**: Depends on US1+US2 (needs Build() to exist).
+  Can run in parallel with US3 since it validates existing
+  behavior rather than adding new methods.
+- **Integration (Phase 6)**: Depends on all user stories
+  complete.
+
+### Within Each User Story
+
+1. Tests MUST be written and FAIL before implementation
+2. Types/structs before methods
+3. Methods before Build() logic
+4. Verify tests pass after implementation
+
+### Parallel Opportunities
+
+- **Phase 2**: T003, T004, T005 (tests) can run in parallel
+- **Phase 3**: T009-T014 (tests) can run in parallel
+- **Phase 4**: T021-T024 (tests) can run in parallel
+- **Phase 5**: T028, T029 (tests) can run in parallel
+- **Phase 4 and Phase 5**: Can run in parallel after Phase 3
+- **Phase 7**: T035-T039 and T042 can all run in parallel
+
+---
+
+## Parallel Example: Phase 3 (US1+US2)
+
+```text
+# Write all US1+US2 tests in parallel (same file, diff funcs):
+T009: Tests for single-field AND filters
+T010: Tests for multi-field AND filters
+T011: Tests for default type and override
+T012: Tests for generic Field() method
+T013: Test for empty/minimal build
+T014: Test for last-write-wins behavior
+
+# Then implement sequentially:
+T015: FilterBuilder struct + NewFilterBuilder
+T016: Named methods (Region, Service, SKU, etc.)
+T017: Type() method
+T018: Field() method
+T019: Build() for AND-only
+T020: Verify all tests pass
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1+US2 Only)
+
+1. Complete Phase 1: Setup (2 tasks)
+2. Complete Phase 2: Foundational (6 tasks)
+3. Complete Phase 3: US1+US2 (12 tasks)
+4. **STOP and VALIDATE**: Run `make test`, verify all
+   acceptance scenarios
+5. This delivers core AND filtering with default type
+
+### Incremental Delivery
+
+1. Setup + Foundational -> Core types ready
+2. US1+US2 -> AND filters work (MVP)
+3. US3 -> OR logic + fluent chaining added
+4. US4 -> Edge cases validated
+5. Integration -> Client uses FilterBuilder
+6. Polish -> Constitution compliant
+
+### Task Summary
+
+| Phase        | Tasks   | Story    | Parallel      |
+|--------------|---------|----------|---------------|
+| Setup        | T001-02 | —        | No            |
+| Foundational | T003-08 | —        | T003-05       |
+| US1+US2      | T009-20 | US1, US2 | T009-14       |
+| US3          | T021-27 | US3      | T021-24       |
+| US4          | T028-31 | US4      | T028-29       |
+| Integration  | T032-34 | —        | No            |
+| Polish       | T035-42 | —        | T035-39,T042  |
+| **Total**    | **42**  |          |               |
+
+### Suggested MVP Scope
+
+Phase 1 + Phase 2 + Phase 3 (US1+US2) = 20 tasks.
+Delivers core AND filtering with default pricing type,
+which is the primary use case covering both P1 stories.
+
+---
+
+## Notes
+
+- [P] tasks = different functions in same file, no deps
+- [US*] label maps task to specific user story
+- All tests are table-driven per constitution
+- `make test` includes `-race` flag
+- `make lint` timeout may exceed 5 minutes
+- Single quotes in values: `'` becomes `''` (OData v4)
+- Default type `priceType eq 'Consumption'` is a behavioral
+  change from existing `buildFilterQuery()` — update tests


### PR DESCRIPTION
## Summary

- Add fluent `FilterBuilder` API for constructing OData `$filter` query strings for the Azure Retail Prices API
- Support for all pricing-relevant fields: `armRegionName`, `armSkuName`, `serviceName`, `serviceFamily`, `priceType`, `meterName`, `productName`, `skuName`, `currencyCode`
- OR-group support for multi-value filters (e.g., multiple regions)
- Generic `Field()` method for arbitrary OData fields
- Default `priceType=Consumption` included unless explicitly overridden via `Type()`
- Integrated with existing `PriceQuery` struct via `BuildFilter()` method
- Comprehensive test coverage with 563 lines of tests

## Test plan

- [x] Unit tests for all builder methods (`Region`, `Service`, `SKU`, `Currency`, etc.)
- [x] OR-group combining tests
- [x] Default priceType behavior tests
- [x] Field escaping and edge case tests
- [x] Integration with `PriceQuery.BuildFilter()`
- [x] `make test` passes
- [x] `make lint` passes

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an OData filter query builder for constructing Azure pricing filters with a fluent, chainable API.

* **Documentation**
  * Enhanced Azure client documentation covering Retry Policy exponential backoff strategy and comprehensive Error Handling guidelines.
  * Added complete OData filter builder specification and quickstart guide with usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->