### PR TITLE
feat(azureclient): add pagination handler with safety limit and progr…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@
 - Go 1.25.5 + `github.com/hashicorp/go-retryablehttp` (HTTP retry), (008-azure-error-handling)
 - Go 1.25.5 + None new — pure Go stdlib (`fmt`, `strings`, `sort`) (009-odata-filter-builder)
 - N/A — pure data transformation (string builder), no I/O (009-odata-filter-builder)
+- N/A — stateless, in-memory only (010-pagination-handler)
 
 ## Recent Changes
 - 002-grpc-server-port: Added Go 1.25.5

--- a/internal/azureclient/client.go
+++ b/internal/azureclient/client.go
@@ -107,7 +107,7 @@ func (c *Client) Close() {
 
 // GetPrices queries the Azure Retail Prices API with the given filter.
 // It automatically handles pagination and returns all matching price items.
-// A safety limit of 1000 pages is enforced to prevent infinite loops.
+// A safety limit of 10 pages is enforced to prevent infinite loops.
 // All errors include query context (region, SKU, service) for debugging.
 func (c *Client) GetPrices(ctx context.Context, query PriceQuery) ([]PriceItem, error) {
 	var allItems []PriceItem
@@ -127,6 +127,13 @@ func (c *Client) GetPrices(ctx context.Context, query PriceQuery) ([]PriceItem, 
 			return nil, fmt.Errorf("%s page %d: %w", qctx, page, err)
 		}
 		allItems = append(allItems, items...)
+		if page > 0 {
+			c.logger.Debug().
+				Int("page", page).
+				Int("items_this_page", len(items)).
+				Int("total_items", len(allItems)).
+				Msg("pagination progress")
+		}
 		requestURL = nextURL
 	}
 

--- a/internal/azureclient/client_test.go
+++ b/internal/azureclient/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -165,6 +166,464 @@ func TestClient_GetPrices_Pagination(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("expected 2 API calls for pagination, got %d", callCount)
+	}
+}
+
+func makePriceItems(start, count int) []PriceItem {
+	items := make([]PriceItem, 0, count)
+	for i := 0; i < count; i++ {
+		idx := start + i
+		items = append(items, PriceItem{
+			ArmSkuName:   fmt.Sprintf("SKU-%03d", idx),
+			RetailPrice:  float64(idx) / 1000,
+			CurrencyCode: "USD",
+		})
+	}
+	return items
+}
+
+func TestClient_GetPrices_ThreePageQueryReturnsAll250Items(t *testing.T) {
+	pages := [][]PriceItem{
+		makePriceItems(1, 100),
+		makePriceItems(101, 100),
+		makePriceItems(201, 50),
+	}
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		pageIndex := callCount - 1
+		if pageIndex >= len(pages) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Logf("unexpected request for page %d", callCount)
+			return
+		}
+
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items:           pages[pageIndex],
+			Count:           len(pages[pageIndex]),
+		}
+		if callCount < len(pages) {
+			resp.NextPageLink = fmt.Sprintf("http://%s/page%d", r.Host, callCount+1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prices) != 250 {
+		t.Fatalf("expected 250 prices, got %d", len(prices))
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 page requests, got %d", callCount)
+	}
+	if prices[0].ArmSkuName != "SKU-001" {
+		t.Errorf("expected first item SKU-001, got %s", prices[0].ArmSkuName)
+	}
+	if prices[len(prices)-1].ArmSkuName != "SKU-250" {
+		t.Errorf("expected last item SKU-250, got %s", prices[len(prices)-1].ArmSkuName)
+	}
+}
+
+func TestClient_GetPrices_SinglePageQueryDoesNotRequestAdditionalPages(t *testing.T) {
+	callCount := 0
+	items := makePriceItems(1, 50)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items:           items,
+			Count:           len(items),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prices) != 50 {
+		t.Fatalf("expected 50 prices, got %d", len(prices))
+	}
+	if callCount != 1 {
+		t.Fatalf("expected exactly 1 API call, got %d", callCount)
+	}
+}
+
+func TestClient_GetPrices_EmptyPageWithNextLinkFollowsPagination(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := PriceResponse{BillingCurrency: "USD"}
+
+		if callCount == 1 {
+			resp.Items = []PriceItem{}
+			resp.Count = 0
+			resp.NextPageLink = fmt.Sprintf("http://%s/page2", r.Host)
+		} else {
+			resp.Items = []PriceItem{
+				{ArmSkuName: "SKU-201", RetailPrice: 0.201, CurrencyCode: "USD"},
+				{ArmSkuName: "SKU-202", RetailPrice: 0.202, CurrencyCode: "USD"},
+			}
+			resp.Count = 2
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prices) != 2 {
+		t.Fatalf("expected 2 prices from second page, got %d", len(prices))
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func TestClient_GetPrices_ContextCancellationMidPagination(t *testing.T) {
+	firstPageDone := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch callCount {
+		case 1:
+			resp := PriceResponse{
+				BillingCurrency: "USD",
+				Items:           []PriceItem{{ArmSkuName: "SKU-001", RetailPrice: 0.001, CurrencyCode: "USD"}},
+				Count:           1,
+				NextPageLink:    fmt.Sprintf("http://%s/page2", r.Host),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Logf("error encoding response: %v", err)
+			}
+			close(firstPageDone)
+		case 2:
+			<-ctx.Done()
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	config.RetryMax = 0
+	config.RetryWaitMin = 1 * time.Millisecond
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, getErr := client.GetPrices(ctx, PriceQuery{})
+		errCh <- getErr
+	}()
+
+	select {
+	case <-firstPageDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first page")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected context cancellation error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for GetPrices to return")
+	}
+}
+
+func TestClient_GetPrices_ExceedingTenPagesReturnsPaginationLimitExceeded(t *testing.T) {
+	const requestedPages = MaxPaginationPages + 1
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items: []PriceItem{
+				{
+					ArmSkuName:   fmt.Sprintf("SKU-%03d", callCount),
+					RetailPrice:  float64(callCount) / 1000,
+					CurrencyCode: "USD",
+				},
+			},
+			Count: 1,
+		}
+		if callCount < requestedPages {
+			resp.NextPageLink = fmt.Sprintf("http://%s/page%d", r.Host, callCount+1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = client.GetPrices(context.Background(), PriceQuery{
+		ArmRegionName: "eastus",
+		ArmSkuName:    "Standard_B1s",
+	})
+
+	if err == nil {
+		t.Fatal("expected pagination limit exceeded error")
+	}
+	if !errors.Is(err, ErrPaginationLimitExceeded) {
+		t.Fatalf("expected ErrPaginationLimitExceeded, got %v", err)
+	}
+	if callCount != MaxPaginationPages {
+		t.Fatalf("expected %d page requests before limit error, got %d", MaxPaginationPages, callCount)
+	}
+}
+
+func TestClient_GetPrices_ExactlyTenPagesSucceeds(t *testing.T) {
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items: []PriceItem{
+				{
+					ArmSkuName:   fmt.Sprintf("SKU-%03d", callCount),
+					RetailPrice:  float64(callCount) / 1000,
+					CurrencyCode: "USD",
+				},
+			},
+			Count: 1,
+		}
+		if callCount < MaxPaginationPages {
+			resp.NextPageLink = fmt.Sprintf("http://%s/page%d", r.Host, callCount+1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("expected success for exactly %d pages, got %v", MaxPaginationPages, err)
+	}
+	if len(prices) != MaxPaginationPages {
+		t.Fatalf("expected %d prices, got %d", MaxPaginationPages, len(prices))
+	}
+	if callCount != MaxPaginationPages {
+		t.Fatalf("expected %d page requests, got %d", MaxPaginationPages, callCount)
+	}
+}
+
+func TestClient_GetPrices_MultiPageQueryLogsPaginationProgress(t *testing.T) {
+	callCount := 0
+	pageSizes := []int{100, 100, 50}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount > len(pageSizes) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items:           makePriceItems((callCount-1)*100+1, pageSizes[callCount-1]),
+			Count:           pageSizes[callCount-1],
+		}
+		if callCount < len(pageSizes) {
+			resp.NextPageLink = fmt.Sprintf("http://%s/page%d", r.Host, callCount+1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	var logBuf strings.Builder
+	logger := zerolog.New(&logBuf)
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	config.Logger = logger
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prices) != 250 {
+		t.Fatalf("expected 250 prices, got %d", len(prices))
+	}
+
+	var progressEntries []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if msg, ok := entry["message"].(string); ok && msg == "pagination progress" {
+			progressEntries = append(progressEntries, entry)
+		}
+	}
+
+	if len(progressEntries) != 2 {
+		t.Fatalf("expected 2 pagination progress logs, got %d (logs: %s)", len(progressEntries), logBuf.String())
+	}
+
+	expected := []struct {
+		page       int
+		itemsThis  int
+		totalItems int
+	}{
+		{page: 1, itemsThis: 100, totalItems: 200},
+		{page: 2, itemsThis: 50, totalItems: 250},
+	}
+
+	for i, want := range expected {
+		entry := progressEntries[i]
+
+		level, ok := entry["level"].(string)
+		if !ok || level != "debug" {
+			t.Fatalf("expected debug log level, got %v", entry["level"])
+		}
+
+		pageVal, ok := entry["page"].(float64)
+		if !ok || int(pageVal) != want.page {
+			t.Fatalf("expected page=%d, got %v", want.page, entry["page"])
+		}
+
+		itemsVal, ok := entry["items_this_page"].(float64)
+		if !ok || int(itemsVal) != want.itemsThis {
+			t.Fatalf("expected items_this_page=%d, got %v", want.itemsThis, entry["items_this_page"])
+		}
+
+		totalVal, ok := entry["total_items"].(float64)
+		if !ok || int(totalVal) != want.totalItems {
+			t.Fatalf("expected total_items=%d, got %v", want.totalItems, entry["total_items"])
+		}
+	}
+}
+
+func TestClient_GetPrices_SinglePageQueryEmitsNoPaginationProgressLogs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := PriceResponse{
+			BillingCurrency: "USD",
+			Items:           makePriceItems(1, 50),
+			Count:           50,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Logf("error encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	var logBuf strings.Builder
+	logger := zerolog.New(&logBuf)
+
+	config := DefaultConfig()
+	config.BaseURL = server.URL
+	config.Logger = logger
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prices, err := client.GetPrices(context.Background(), PriceQuery{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prices) != 50 {
+		t.Fatalf("expected 50 prices, got %d", len(prices))
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(logBuf.String()), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if msg, ok := entry["message"].(string); ok && msg == "pagination progress" {
+			t.Fatalf("did not expect pagination progress log on single-page query, got log: %v", entry)
+		}
 	}
 }
 

--- a/internal/azureclient/errors.go
+++ b/internal/azureclient/errors.go
@@ -7,7 +7,7 @@ import (
 
 // MaxPaginationPages is a safety limit to prevent infinite pagination loops.
 // Used by both client.go (pagination logic) and the ErrPaginationLimitExceeded message.
-const MaxPaginationPages = 1000
+const MaxPaginationPages = 10
 
 // Sentinel errors returned by the client.
 var (

--- a/specs/010-pagination-handler/checklists/requirements.md
+++ b/specs/010-pagination-handler/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Pagination Handler for Azure API Responses
+
+**Purpose**: Validate specification completeness and quality before
+proceeding to planning
+**Created**: 2026-03-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The page limit of 10 (FR-003) comes directly from the issue requirements.
+- No [NEEDS CLARIFICATION] markers were needed — the issue provided clear,
+  complete requirements with specific numbers and expected behaviors.

--- a/specs/010-pagination-handler/contracts/pagination-contract.md
+++ b/specs/010-pagination-handler/contracts/pagination-contract.md
@@ -1,0 +1,53 @@
+# Pagination Contract
+
+**Feature**: `010-pagination-handler`
+
+## API Surface
+
+No new public API surface is introduced. The pagination handler is
+an internal behavior change to the existing `GetPrices()` method.
+
+### Existing Method (unchanged signature)
+
+```go
+func (c *Client) GetPrices(
+    ctx context.Context,
+    query PriceQuery,
+) ([]PriceItem, error)
+```
+
+### Behavioral Contract Changes
+
+#### Page Limit
+
+- **Before**: Max 1000 pages per query
+- **After**: Max 10 pages per query (~1,000 items)
+- **Error**: Returns `ErrPaginationLimitExceeded` when limit exceeded
+- **Detection**: `errors.Is(err, azureclient.ErrPaginationLimitExceeded)`
+
+#### Pagination Progress Logging
+
+- **Level**: Debug
+- **Message**: `"pagination progress"`
+- **Fields**:
+  - `page` (int): Current page number (1-indexed in logs)
+  - `items_this_page` (int): Items returned in current page
+  - `total_items` (int): Cumulative items across all pages so far
+- **Condition**: Emitted for each page after the first (page >= 1)
+
+### Existing Sentinel Errors (unchanged)
+
+```go
+var ErrPaginationLimitExceeded  // pagination limit exceeded (10 pages)
+var ErrNotFound                 // not found (zero results)
+var ErrRateLimited              // rate limited (HTTP 429)
+var ErrServiceUnavailable       // service unavailable (HTTP 503)
+var ErrRequestFailed            // request failed (other errors)
+var ErrInvalidResponse          // invalid API response
+```
+
+### Existing Constant (value change only)
+
+```go
+const MaxPaginationPages = 10  // was 1000
+```

--- a/specs/010-pagination-handler/data-model.md
+++ b/specs/010-pagination-handler/data-model.md
@@ -1,0 +1,79 @@
+# Data Model: Pagination Handler
+
+**Feature**: `010-pagination-handler`
+**Date**: 2026-03-01
+
+## Entities
+
+### Existing Entities (no changes)
+
+#### PriceResponse
+
+Envelope for a single API page. Already contains all required fields.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| BillingCurrency | string | Currency code (e.g., "USD") |
+| CustomerEntityID | string | Customer entity identifier |
+| CustomerEntityType | string | Pricing type ("Retail") |
+| Items | []PriceItem | Price entries for this page |
+| NextPageLink | string | URL for next page, empty if none |
+| Count | int | Number of items in this page |
+
+#### PriceItem
+
+Individual price entry. No changes needed.
+
+#### PriceQuery
+
+Filter parameters. No changes needed.
+
+#### Config
+
+Client configuration. No changes needed — page limit is a constant,
+not configurable.
+
+### Modified Constants
+
+| Constant | Current | New | Location |
+| --- | --- | --- | --- |
+| MaxPaginationPages | 1000 | 10 | errors.go |
+
+### No New Entities
+
+No new types, structs, or interfaces are introduced. The pagination
+handler operates on existing data structures. The only data flow
+change is adding structured log events during the pagination loop.
+
+## State Transitions
+
+```text
+GetPrices() pagination flow:
+
+  [Start] → Build initial URL from PriceQuery
+    │
+    ▼
+  [Fetch Page N] → fetchPage(ctx, url)
+    │
+    ├── Error → Return (nil, wrapped error with page N)
+    │
+    ├── Success + NextPageLink present + page < limit
+    │     │
+    │     ├── Log progress (debug): page N, items, total
+    │     │
+    │     └── Append items → [Fetch Page N+1]
+    │
+    ├── Success + NextPageLink empty
+    │     │
+    │     └── Append items → [Check Results]
+    │
+    └── Success + page >= limit
+          │
+          └── Return (nil, ErrPaginationLimitExceeded)
+
+  [Check Results]
+    │
+    ├── len(allItems) == 0 → Return (nil, ErrNotFound)
+    │
+    └── len(allItems) > 0 → Return (allItems, nil)
+```

--- a/specs/010-pagination-handler/plan.md
+++ b/specs/010-pagination-handler/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Pagination Handler for Azure API Responses
+
+**Branch**: `010-pagination-handler` | **Date**: 2026-03-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-pagination-handler/spec.md`
+
+## Summary
+
+Refine the existing pagination logic in `GetPrices()` to enforce a
+10-page safety limit (down from 1000), add structured pagination
+progress logging, and expand test coverage to meet the spec's
+acceptance scenarios. The pagination loop and `fetchPage()` method
+already exist; this is a targeted enhancement, not a greenfield
+implementation.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: `github.com/hashicorp/go-retryablehttp`
+(HTTP retry), `github.com/rs/zerolog` (structured logging)
+**Storage**: N/A — stateless, in-memory only
+**Testing**: `go test` with `httptest` mock servers, table-driven tests
+**Target Platform**: Linux server (gRPC plugin)
+**Project Type**: Single project (Go library package)
+**Performance Goals**: Multi-page queries complete within 10 *
+per-page latency (<2s p95 per page)
+**Constraints**: Max 10 pages per query (~1,000 items),
+no partial results on limit exceeded
+**Scale/Scope**: Azure Retail Prices API, ~100 items per page
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1
+design.*
+
+- [x] **Code Quality**: Plan includes linting checks, error handling
+  strategy, and complexity justification (if needed)
+- [x] **Testing**: Plan includes TDD workflow (tests before
+  implementation), >=80% coverage target, race detector for concurrent
+  code
+- [x] **User Experience**: Plan addresses plugin lifecycle (port
+  announcement, health checks, graceful shutdown), observability
+  (structured logging), and error handling
+- [x] **Documentation**: Plan includes godoc comments for exported
+  functions, README updates, CLAUDE.md updates if workflow changes,
+  and docstring coverage >=80% target
+- [x] **Performance**: Plan includes performance targets (response
+  times, concurrency), reliability guarantees (retry logic, timeout
+  configuration), and resource constraints (connection pooling,
+  cache TTL)
+- [x] **Architectural Constraints**: Plan DOES NOT violate "Hard No's"
+  (no authenticated Azure APIs, no persistent storage, no
+  infrastructure mutation, no bulk data embedding)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-pagination-handler/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/azureclient/
+├── client.go            # GetPrices() pagination loop + fetchPage()
+├── client_test.go       # Unit tests (pagination, errors, logging)
+├── errors.go            # MaxPaginationPages constant + sentinel errors
+├── types.go             # Config, PriceQuery, PriceItem, PriceResponse
+├── filter.go            # OData filter builder
+├── filter_test.go       # Filter builder tests
+└── retry.go             # Custom retry policy + backoff
+
+examples/
+└── azure_client_integration_test.go  # Live API integration tests
+```
+
+**Structure Decision**: No new files needed. All changes are
+modifications to existing files in `internal/azureclient/`.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/010-pagination-handler/quickstart.md
+++ b/specs/010-pagination-handler/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Pagination Handler
+
+**Feature**: `010-pagination-handler`
+
+## Usage
+
+Pagination is fully automatic. No caller changes are needed.
+
+```go
+config := azureclient.DefaultConfig()
+config.Logger = logger // Enable to see pagination progress at debug
+client, err := azureclient.NewClient(config)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Queries that return multiple pages are handled automatically.
+// Up to 10 pages (~1,000 items) are aggregated into a single slice.
+prices, err := client.GetPrices(ctx, azureclient.PriceQuery{
+    ServiceName:  "Virtual Machines",
+    ArmSkuName:   "Standard_D2s_v3",
+    CurrencyCode: "USD",
+})
+if err != nil {
+    if errors.Is(err, azureclient.ErrPaginationLimitExceeded) {
+        // Query returned too many results — narrow your filter
+        log.Printf("too many results, refine query: %v", err)
+    }
+    return err
+}
+
+fmt.Printf("Found %d prices across all pages\n", len(prices))
+```
+
+## Pagination Behavior
+
+| Scenario                      | Result                              |
+|-------------------------------|-------------------------------------|
+| Query matches <100 items      | Single page, no pagination          |
+| Query matches 100-1000 items  | Multi-page, all items returned      |
+| Query matches >1000 items     | Error: `ErrPaginationLimitExceeded` |
+
+## Debug Logging
+
+Enable debug-level logging to see pagination progress:
+
+```text
+{"level":"debug","page":1,"items_this_page":100,"total_items":200,
+ "message":"pagination progress"}
+{"level":"debug","page":2,"items_this_page":100,"total_items":300,
+ "message":"pagination progress"}
+```
+
+## Testing
+
+```bash
+# Unit tests (includes pagination tests)
+make test
+
+# Integration tests (queries live Azure API)
+go test -tags=integration ./examples/...
+```

--- a/specs/010-pagination-handler/research.md
+++ b/specs/010-pagination-handler/research.md
@@ -1,0 +1,115 @@
+# Research: Pagination Handler for Azure API Responses
+
+**Feature**: `010-pagination-handler`
+**Date**: 2026-03-01
+
+## R1: Current Pagination Implementation State
+
+**Decision**: Enhance existing pagination loop, do not rewrite.
+
+**Rationale**: The `GetPrices()` method in `client.go:112-148` already
+implements the full pagination flow: loop over `fetchPage()`, aggregate
+items, check safety limit, handle empty results. The changes needed
+are targeted: reduce `MaxPaginationPages` from 1000 to 10 and add
+progress logging inside the loop.
+
+**Alternatives considered**:
+
+- Separate `paginate()` method extracted from `GetPrices()` — rejected
+  because the loop is only 10 lines and extraction adds indirection
+  without reducing complexity.
+- Iterator/channel-based pagination — rejected because callers need the
+  full result set (no streaming use case exists).
+
+## R2: Page Limit Value
+
+**Decision**: Use constant `MaxPaginationPages = 10`.
+
+**Rationale**: The spec (FR-003) and issue both specify max 10 pages.
+Azure Retail Prices API returns up to 100 items per page
+(confirmed via API documentation and live testing). 10 pages = ~1,000
+items covers all realistic pricing queries (a specific SKU across all
+regions returns ~60-120 items).
+
+**Alternatives considered**:
+
+- Configurable via `Config` struct — rejected per spec. The limit is a
+  safety guard, not a tuning parameter. Can be added later if needed.
+- Higher limit (100, 1000) — rejected. The current value of 1000 was a
+  placeholder. Queries returning >1,000 items indicate a filter that is
+  too broad, not a legitimate use case.
+
+## R3: Pagination Progress Log Level
+
+**Decision**: Use `debug` level for pagination progress logs.
+
+**Rationale**: Per spec assumptions, debug level avoids noise in
+production while remaining available for troubleshooting. Pagination is
+a normal, expected operation — not a warning or error condition. The
+`zerolog` library supports per-level filtering, so operators can enable
+debug logs when investigating slow queries.
+
+**Alternatives considered**:
+
+- `info` level — rejected. Every multi-page query would produce
+  multiple log lines in production. Pagination is internal plumbing,
+  not a user-visible event.
+- `trace` level — rejected. zerolog's `Trace()` is less commonly
+  configured. `debug` is the standard level for "internal flow
+  visibility" in this project.
+
+## R4: Log Fields for Pagination Progress
+
+**Decision**: Log `page` (int), `items_this_page` (int),
+`total_items` (int) fields with message "pagination progress".
+
+**Rationale**: These three fields give operators complete visibility:
+which page was fetched, how many items it contained, and the running
+total. The message "pagination progress" is consistent with the
+existing "pricing query error" message pattern.
+
+**Alternatives considered**:
+
+- Include `next_page_url` — rejected. URLs contain query parameters
+  that are already visible in the initial request. Logging them on
+  every page adds noise.
+- Include query context fields (region, sku, service) — considered
+  but deferred. The query context is already logged on errors. For
+  debug-level progress, the page numbers are sufficient.
+
+## R5: Empty Page with NextPageLink Edge Case
+
+**Decision**: Follow the link. Do not treat empty items as end-of-data.
+
+**Rationale**: Per spec edge case 1, an empty items list with a
+next-page link should be followed because the next page may contain
+results. The existing code handles this correctly — `append(allItems,
+items...)` with an empty slice is a no-op, and the loop continues
+because `nextURL != ""`.
+
+**Alternatives considered**:
+
+- Treat empty page as end — rejected. Azure API documentation does
+  not guarantee non-empty pages. Stopping early could lose data.
+
+## R6: Test Strategy
+
+**Decision**: Add 5 new test cases to `client_test.go` using
+`httptest` mock servers.
+
+**Rationale**: The spec requires testing for: pagination limit exceeded
+(FR-003/FR-004), exactly-at-limit (US3 scenario 2), empty page with
+NextPageLink (edge case), progress logging (FR-005), and context
+cancellation mid-pagination (FR-008). All can be tested with
+`httptest.NewServer` handlers that control response content and
+page count.
+
+**Alternatives considered**:
+
+- Separate `pagination_test.go` file — rejected. Tests are
+  closely related to existing `client_test.go` tests and share the
+  same mock server patterns.
+- Integration test for pagination — already exists implicitly via
+  `TestAzureClient_LiveAPI_VirtualMachines` which queries across
+  regions (may return >100 items). Add explicit multi-page integration
+  test.

--- a/specs/010-pagination-handler/spec.md
+++ b/specs/010-pagination-handler/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Pagination Handler for Azure API Responses
+
+**Feature Branch**: `010-pagination-handler`
+**Created**: 2026-03-01
+**Status**: Draft
+**Input**: GitHub Issue #10 — Implement pagination handler for Azure API responses
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Complete Result Retrieval (Priority: P1)
+
+As cost estimation logic, I want all matching pricing SKUs returned from a query,
+not just the first page, so that cost calculations are accurate and complete.
+
+**Why this priority**: Without full result retrieval, cost estimates are inaccurate
+because queries that match more items than a single page contains silently return
+incomplete data. This is the core reason pagination exists.
+
+**Independent Test**: Can be fully tested by issuing a query that matches more
+items than one page and verifying all matching items appear in the result set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pricing query matches 250 items across 3 pages, **When** the
+   query is executed, **Then** all 250 items are returned in a single result set.
+2. **Given** a pricing query matches 50 items (single page), **When** the query
+   is executed, **Then** all 50 items are returned without any additional page
+   requests.
+
+---
+
+### User Story 2 - Automatic Page Following (Priority: P1)
+
+As the HTTP client, I want to automatically follow pagination links provided by
+the API so that callers receive complete results without manual iteration.
+
+**Why this priority**: Tied to P1 because automatic following is the mechanism
+that enables complete result retrieval. Without it, every caller must implement
+its own pagination logic.
+
+**Independent Test**: Can be tested by verifying that when the API response
+includes a next-page link, the client automatically issues a follow-up request
+to that URL.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API response includes a next-page link, **When** the client
+   processes the response, **Then** it automatically fetches the next page using
+   the provided link.
+2. **Given** the API response does not include a next-page link, **When** the
+   client processes the response, **Then** it stops fetching and returns the
+   collected results.
+
+---
+
+### User Story 3 - Pagination Safety Limit (Priority: P2)
+
+As an operator, I want protection against runaway pagination so that a single
+query cannot consume unbounded resources by fetching an excessive number of pages.
+
+**Why this priority**: Important for operational safety but secondary to core
+functionality. Without a limit, a broad query could loop indefinitely or consume
+excessive memory.
+
+**Independent Test**: Can be tested by simulating a response chain that exceeds
+the page limit and verifying the client stops with an appropriate error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query produces more than the maximum allowed pages, **When** the
+   page limit is reached, **Then** the client stops fetching and returns an error
+   indicating the limit was exceeded.
+2. **Given** a query produces exactly the maximum number of pages, **When** all
+   pages are fetched, **Then** the client returns all items without error.
+
+---
+
+### User Story 4 - Pagination Observability (Priority: P3)
+
+As a developer or operator, I want pagination progress logged so that I can
+debug slow queries and monitor data volume for operational awareness.
+
+**Why this priority**: Useful for debugging and monitoring but not required for
+correct behavior. The system functions correctly without logging.
+
+**Independent Test**: Can be tested by executing a multi-page query and verifying
+that structured log entries include page numbers and item counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query spans multiple pages, **When** each page is fetched,
+   **Then** a log entry is emitted with the current page number and cumulative
+   item count.
+2. **Given** a single-page query, **When** results are returned, **Then** no
+   unnecessary pagination progress logs are emitted.
+
+---
+
+### Edge Cases
+
+- What happens when the API returns an empty items list but includes a next-page
+  link? The client should follow the link (the next page may contain results).
+- What happens when a mid-pagination page request fails? The client should return
+  an error that includes which page failed.
+- What happens when context is cancelled during pagination? The client should
+  stop immediately and return the cancellation error.
+- What happens when the next-page link is malformed or unreachable? The client
+  should return an error rather than silently discarding partial results.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST follow next-page links in API responses until no
+  further pages exist.
+- **FR-002**: System MUST aggregate items from all fetched pages into a single
+  result set returned to the caller.
+- **FR-003**: System MUST enforce a maximum page limit of 10 pages (approximately
+  1,000 items) per query to prevent unbounded resource consumption.
+- **FR-004**: System MUST return a specific error when the page limit is exceeded,
+  clearly indicating the limit was reached.
+- **FR-005**: System MUST log pagination progress with the current page number
+  and cumulative item count for each page beyond the first.
+- **FR-006**: System MUST stop pagination when the API response contains no
+  next-page link (end of results).
+- **FR-007**: System MUST reuse the same HTTP transport for follow-up page
+  requests, preserving retry and timeout behavior.
+- **FR-008**: System MUST propagate context cancellation during pagination,
+  stopping immediately if the caller cancels.
+- **FR-009**: System MUST include the page number in any error returned during
+  pagination so callers can identify which page failed.
+
+### Key Entities
+
+- **Page**: A single API response containing a batch of items and an optional
+  link to the next page. Key attributes: item list, item count, next-page link
+  (optional).
+- **Result Set**: The aggregated collection of all items across all pages for a
+  single query. Represents the complete answer to a pricing query.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Queries returning up to 1,000 items (10 pages) return complete
+  results in a single call without caller intervention.
+- **SC-002**: Queries exceeding the page limit fail with a clear, identifiable
+  error within one request cycle after the limit page.
+- **SC-003**: Multi-page queries include structured log entries for each page
+  with page number and item count.
+- **SC-004**: All existing single-page query behavior remains unchanged — no
+  regressions in current functionality.
+- **SC-005**: Test coverage for pagination logic is at least 80%, covering
+  single-page, multi-page, limit-exceeded, and error-mid-pagination scenarios.
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations
+  (>=80% for business logic)
+- [x] Error handling strategy is defined (no silent failures)
+- [x] Code complexity is considered (functions <15 cyclomatic complexity)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then format)
+- [x] Integration test needs identified (external API interactions)
+- [x] Performance test criteria specified (if applicable)
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable
+- [x] Response time expectations defined (e.g., cache hits <10ms, API calls <2s p95)
+- [x] Observability requirements specified (logging, metrics)
+
+### Documentation
+
+- [x] README.md updates identified (if user-facing changes)
+- [x] API documentation needs outlined (godoc comments, contracts)
+- [x] Docstring coverage >=80% maintained (all exported symbols documented)
+- [x] Examples/quickstart guide planned (if new capability)
+
+### Performance & Reliability
+
+- [x] Performance targets specified (response times, throughput)
+- [x] Reliability requirements defined (retry logic, error handling)
+- [x] Resource constraints considered (memory, connections, cache TTL)
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The API returns a maximum of 100 items per page (Azure Retail Prices API
+  default). The 10-page limit therefore corresponds to approximately 1,000 items.
+- Next-page links are fully-qualified URLs that can be used directly without
+  further construction or encoding.
+- The retry policy already configured on the HTTP transport applies equally to
+  initial requests and follow-up page requests.
+- Pagination progress logging uses structured (JSON) log output at
+  debug level to avoid noise in production while remaining available
+  for troubleshooting.

--- a/specs/010-pagination-handler/tasks.md
+++ b/specs/010-pagination-handler/tasks.md
@@ -1,0 +1,219 @@
+# Tasks: Pagination Handler for Azure API Responses
+
+**Input**: Design documents from `/specs/010-pagination-handler/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included per spec SC-005 (>=80% coverage for pagination logic).
+
+**Organization**: Tasks grouped by user story. US1 and US2 share P1 priority and the
+same code path — listed as separate phases but can be implemented in a single pass.
+All changes modify existing files in `internal/azureclient/`; no new files are created.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup needed — enhancement to existing package `internal/azureclient/`.
+
+_No tasks in this phase._
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Change the pagination constant and update documentation to reflect the
+new 10-page limit. All subsequent tests depend on this value.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T001 [P] Update `MaxPaginationPages` constant from 1000 to 10 in `internal/azureclient/errors.go`
+- [X] T002 [P] Update `GetPrices()` docstring to reflect 10-page limit instead of 1000 in `internal/azureclient/client.go`
+
+**Checkpoint**: Constant and docstring reflect the new 10-page limit. Run `make test` — all existing tests still pass.
+
+---
+
+## Phase 3: User Story 1 — Complete Result Retrieval (Priority: P1) MVP
+
+**Goal**: Verify that queries returning multiple pages aggregate all items into a single result set.
+
+**Independent Test**: Issue a query matching 250 items across 3 pages and verify all 250 items appear in the result.
+
+### Tests for User Story 1
+
+- [X] T003 [US1] Add test for 3-page query (250 items across 3 pages) returning all 250 items in `internal/azureclient/client_test.go`
+- [X] T004 [US1] Add test for single-page query (50 items) verifying no additional page requests via call count in `internal/azureclient/client_test.go`
+
+**Checkpoint**: Multi-page aggregation verified. No implementation changes needed — existing pagination loop handles this correctly.
+
+---
+
+## Phase 4: User Story 2 — Automatic Page Following (Priority: P1)
+
+**Goal**: Verify that the client automatically follows NextPageLink and handles edge cases correctly.
+
+**Independent Test**: Verify that when a page has a NextPageLink, the client fetches the next page automatically, including edge cases like empty pages and mid-pagination cancellation.
+
+### Tests for User Story 2
+
+- [X] T005 [US2] Add test for empty items list with NextPageLink — client follows link and returns items from subsequent page in `internal/azureclient/client_test.go`
+- [X] T006 [US2] Add test for context cancellation mid-pagination (cancel after first page succeeds) in `internal/azureclient/client_test.go`
+
+**Checkpoint**: Page following and cancellation edge cases verified. Existing `TestGetPrices_MidPaginationErrorIncludesPage` already covers mid-pagination HTTP errors.
+
+---
+
+## Phase 5: User Story 3 — Pagination Safety Limit (Priority: P2)
+
+**Goal**: Enforce a 10-page maximum and return `ErrPaginationLimitExceeded` when exceeded.
+
+**Independent Test**: Simulate a response chain exceeding 10 pages and verify the client stops with the correct error. Also verify exactly 10 pages succeeds.
+
+### Tests for User Story 3
+
+- [X] T007 [P] [US3] Add test for query exceeding 10-page limit returning `ErrPaginationLimitExceeded` in `internal/azureclient/client_test.go`
+- [X] T008 [P] [US3] Add test for query returning exactly 10 pages succeeding without error in `internal/azureclient/client_test.go`
+
+**Checkpoint**: Safety limit enforcement verified at boundary (10 pages) and beyond (11+ pages).
+
+---
+
+## Phase 6: User Story 4 — Pagination Observability (Priority: P3)
+
+**Goal**: Add structured debug-level logging for pagination progress with page number and cumulative item count.
+
+**Independent Test**: Execute a multi-page query and verify structured log entries include `page`, `items_this_page`, and `total_items` fields.
+
+### Implementation for User Story 4
+
+- [X] T009 [US4] Add pagination progress logging (debug level, message `"pagination progress"`) to `GetPrices()` loop in `internal/azureclient/client.go` with fields: `page` (int), `items_this_page` (int), `total_items` (int) — emit for each page after the first
+
+### Tests for User Story 4
+
+- [X] T010 [US4] Add test for multi-page query emitting structured log entries with `page`, `items_this_page`, `total_items` fields in `internal/azureclient/client_test.go`
+- [X] T011 [US4] Add test for single-page query emitting no pagination progress logs in `internal/azureclient/client_test.go`
+
+**Checkpoint**: Pagination progress is observable via structured debug logs. Single-page queries produce no noise.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, quality gates, and documentation updates.
+
+### Constitution Compliance Tasks
+
+- [X] T012 [P] Run `make lint` and fix all linting issues
+- [X] T013 [P] Run `make test` with `-race` flag to verify thread safety (`go test -race ./internal/azureclient/...`)
+- [X] T014 [P] Verify test coverage >=80% for pagination logic (`go test -cover ./internal/azureclient/...`)
+- [X] T015 [P] Verify godoc comments on all exported symbols meet >=80% docstring coverage
+- [X] T016 [P] Update CLAUDE.md with pagination handler documentation if patterns changed
+
+### Additional Validation
+
+- [X] T017 Run quickstart.md validation — verify code examples compile and match implementation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — start immediately. BLOCKS all user stories.
+- **US1 (Phase 3)**: Depends on Phase 2 completion.
+- **US2 (Phase 4)**: Depends on Phase 2 completion. Independent of US1.
+- **US3 (Phase 5)**: Depends on Phase 2 completion. Independent of US1/US2.
+- **US4 (Phase 6)**: Depends on Phase 2 completion. Independent of US1/US2/US3.
+- **Polish (Phase 7)**: Depends on all user story phases (3–6) being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2 — no dependencies on other stories
+- **US2 (P1)**: Can start after Phase 2 — independent of US1 (tests different behavior)
+- **US3 (P2)**: Can start after Phase 2 — independent of US1/US2
+- **US4 (P3)**: Can start after Phase 2 — has implementation (T009) before tests (T010, T011)
+
+### Within Each User Story
+
+- Tests written FIRST, verified to FAIL before implementation (where applicable)
+- US1/US2/US3: Test-only phases (implementation is existing code or Phase 2 constant change)
+- US4: Implementation (T009) MUST precede test tasks (T010, T011)
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files: `errors.go` vs `client.go`)
+- T007 and T008 are independent test cases (marked [P])
+- T012–T016 can all run in parallel (independent validation tasks)
+- All user story phases (3–6) could run in parallel if staffed independently
+
+---
+
+## Parallel Example: Foundational Phase
+
+```text
+# These edits are in different files (marked [P]):
+Task T001: "Update MaxPaginationPages in errors.go"
+Task T002: "Update GetPrices docstring in client.go"
+```
+
+## Parallel Example: User Story 3
+
+```text
+# These tests are independent (marked [P]):
+Task T007: "Test exceeding 10-page limit returns ErrPaginationLimitExceeded"
+Task T008: "Test exactly 10 pages succeeds without error"
+```
+
+## Parallel Example: Polish Phase
+
+```text
+# These validation tasks are independent (marked [P]):
+Task T012: "Run make lint"
+Task T013: "Run make test -race"
+Task T014: "Verify test coverage"
+Task T015: "Verify docstring coverage"
+Task T016: "Update CLAUDE.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (change constant, update docstring)
+2. Complete Phase 3: US1 (verify multi-page aggregation)
+3. **STOP and VALIDATE**: Run `make test` — all tests pass
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready (constant + docstring)
+2. Phase 3: US1 → Multi-page aggregation verified (MVP!)
+3. Phase 4: US2 → Edge cases verified
+4. Phase 5: US3 → Safety limit enforced at boundary
+5. Phase 6: US4 → Observability added with structured logging
+6. Phase 7 → Quality gates passed, docs updated
+
+### Single Developer (Recommended)
+
+All changes are in 3 files (`errors.go`, `client.go`, `client_test.go`).
+Execute phases sequentially: 2 → 3 → 4 → 5 → 6 → 7.
+
+---
+
+## Notes
+
+- All changes modify existing files — no new files created
+- Source files: `internal/azureclient/errors.go`, `internal/azureclient/client.go`, `internal/azureclient/client_test.go`
+- Tests use `httptest.NewServer` with controlled handlers for deterministic behavior
+- The pagination loop already works correctly — this feature reduces the limit and adds observability
+- Existing test `TestGetPrices_MidPaginationErrorIncludesPage` already covers mid-pagination HTTP failure edge case
+- Existing test `TestClient_GetPrices_Pagination` covers basic 2-page following
+- [P] tasks = different files or independent test cases, no dependencies
+- [Story] label maps task to specific user story for traceability


### PR DESCRIPTION
…ess logging

## Summary

- Reduce `MaxPaginationPages` from 1000 to 10 to enforce a practical safety limit against runaway pagination loops
- Add structured debug logging for pagination progress showing page number, items per page, and running total
- Add 8 comprehensive unit tests covering multi-page traversal, single-page queries, empty pages, context cancellation, pagination limit enforcement, and log output verification

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] 8 new pagination-specific test functions added
- [x] Boundary tests for exactly 10 pages (succeeds) and 11 pages (returns `ErrPaginationLimitExceeded`)

## Changes

### Modified files

- `internal/azureclient/errors.go` - Lower `MaxPaginationPages` constant from 1000 to 10
- `internal/azureclient/client.go` - Add debug-level pagination progress logging after page 0
- `internal/azureclient/client_test.go` - Add `makePriceItems` helper and 8 new pagination test functions

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination progress debug logging displaying page number, items per page, and total items tracked.
  * Comprehensive pagination handler documentation including quickstart guide and usage examples.

* **Bug Fixes**
  * Reduced maximum pagination safety limit from 1000 to 10 pages per query for improved API response handling.

* **Documentation**
  * Added specification, research, plan, and contract documentation for pagination handler feature.
  * Added requirements checklist and data model documentation.

* **Tests**
  * Expanded test coverage for multi-page pagination, edge cases, and pagination limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->