### PR TITLE
feat(azureclient): complete cache layer with TTL eviction and observa…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@
 - N/A — pure data transformation (string builder), no I/O (009-odata-filter-builder)
 - In-memory only (stateless constraint) (012-memory-cache)
 - N/A — stateless, in-memory only (010-pagination-handler)
+- Go 1.25.7 + `github.com/hashicorp/golang-lru/v2/expirable`, (015-cache-completion)
+- N/A — in-memory only (stateless constraint) (015-cache-completion)
 
 ## Recent Changes
 - 002-grpc-server-port: Added Go 1.25.5

--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ Run the binary directly. It starts a gRPC server and outputs the port to stdout:
 
 ## Environment Variables
 
-| Variable               | Description                                   | Default   |
-|------------------------|-----------------------------------------------|-----------|
-| `FINFOCUS_PLUGIN_PORT` | Fixed port number for the gRPC server         | Ephemeral |
-| `FINFOCUS_LOG_LEVEL`   | Log level: trace, debug, info, warn, error    | info      |
+<!-- markdownlint-disable MD013 -->
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FINFOCUS_PLUGIN_PORT` | Ephemeral | Fixed port number for the gRPC server |
+| `FINFOCUS_LOG_LEVEL` | info | Log level: trace, debug, info, warn, error |
+| `FINFOCUS_CACHE_TTL` | 24h | Cache TTL (e.g., "10s", "1h", "0s" to disable) |
+
+<!-- markdownlint-enable MD013 -->
 
 ### Examples
 

--- a/specs/015-cache-completion/checklists/requirements.md
+++ b/specs/015-cache-completion/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Cache Layer Completion (v0.3.0 Gaps)
+
+**Purpose**: Validate specification completeness and quality before
+proceeding to planning
+**Created**: 2026-03-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation
+  details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Scope is intentionally narrow: only two gaps from the broader #13
+  and #15 issues. All other criteria were already met by #12.
+- The assumption about eviction reason inference (LRU vs TTL) is
+  documented. If the library does not provide this distinction, the
+  implementation may log a generic "evicted" reason.

--- a/specs/015-cache-completion/data-model.md
+++ b/specs/015-cache-completion/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: Cache Layer Completion
+
+No new entities are introduced. This feature modifies the behavior of
+existing entities only.
+
+## Modified Entities
+
+### CachedClient (internal/azureclient/cache.go)
+
+**Current state**: `expirable.NewLRU` constructed with `nil` eviction
+callback.
+
+**Change**: Constructor receives a non-nil eviction callback closure
+that logs evicted entries at debug level.
+
+**New behavior**: When any entry is evicted (by TTL or LRU), the
+callback emits a structured log with:
+
+- `cache_key`: The evicted entry's normalized cache key
+- `eviction_reason`: "expired" or "lru" (inferred from entry age)
+
+### CacheConfig (internal/azureclient/cache.go)
+
+**No structural change**. The `TTL` field already exists and is
+configurable. The env var override sets this field before construction.
+
+## Data Flow
+
+```text
+Startup:
+  main.go reads FINFOCUS_CACHE_TTL env var
+    → parses with time.ParseDuration
+    → sets cacheConfig.TTL (or keeps default on error)
+    → passes to NewCachedClient
+
+Eviction:
+  expirable.LRU evicts entry (TTL expiry or LRU overflow)
+    → calls onEvict(key, value) callback
+    → callback infers reason from value.CreatedAt + config.TTL
+    → callback logs at debug level via zerolog
+```

--- a/specs/015-cache-completion/plan.md
+++ b/specs/015-cache-completion/plan.md
@@ -1,0 +1,140 @@
+# Implementation Plan: Cache Layer Completion (v0.3.0 Gaps)
+
+**Branch**: `015-cache-completion` | **Date**: 2026-03-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/015-cache-completion/spec.md`
+
+## Summary
+
+Complete the v0.3.0 Caching Layer milestone by addressing two remaining
+gaps in the CachedClient delivered by #12:
+
+1. **FINFOCUS_CACHE_TTL env var** (#13): Read an environment variable
+   at startup to override the default 24-hour cache TTL, following
+   the existing `FINFOCUS_PLUGIN_PORT` pattern in `main.go`.
+2. **Eviction callback logging** (#15): Register an eviction callback
+   with the `expirable.LRU` to emit debug-level structured logs when
+   entries are evicted.
+
+Both changes are small, isolated, and touch existing files only.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.7
+**Primary Dependencies**: `github.com/hashicorp/golang-lru/v2/expirable`,
+`github.com/rs/zerolog`
+**Storage**: N/A — in-memory only (stateless constraint)
+**Testing**: `go test` with `go test -race` for concurrency
+**Target Platform**: Linux server (gRPC plugin subprocess)
+**Project Type**: Single Go module
+**Performance Goals**: Cache hits <10ms p99, eviction callback <1ms
+**Constraints**: No persistent storage, no authenticated APIs
+**Scale/Scope**: 2 files modified, 2 test files updated, ~50 lines new code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Code Quality**: Linting via `make lint`, error handling for
+  invalid env var values, no new complexity (simple parsing + callback)
+- [x] **Testing**: TDD workflow, tests for env var parsing (valid,
+  invalid, unset, zero), tests for eviction callback logging, race
+  detector required
+- [x] **User Experience**: Startup log shows effective TTL, eviction
+  logs at debug level, invalid env var produces warning with fallback
+- [x] **Documentation**: Godoc on new/modified functions, CLAUDE.md
+  updated with env var, README updated with configuration option
+- [x] **Performance**: Eviction callback is debug log only (zerolog
+  nop at non-debug levels), no allocation overhead on critical path
+- [x] **Architectural Constraints**: No authenticated APIs, no
+  persistent storage, no infrastructure mutation, no bulk data
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-cache-completion/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/finfocus-plugin-azure-public/
+└── main.go                    # MODIFY: add FINFOCUS_CACHE_TTL parsing
+
+internal/azureclient/
+├── cache.go                   # MODIFY: add eviction callback to NewLRU
+├── cache_test.go              # MODIFY: add eviction logging tests
+└── cachekey.go                # NO CHANGE (already complete)
+```
+
+**Structure Decision**: No new files needed. Both changes modify
+existing files in their natural locations. The env var is read in
+`main.go` (following the existing `FINFOCUS_PLUGIN_PORT` pattern) and
+the eviction callback is registered in `cache.go` (where the LRU is
+constructed).
+
+## Design Decisions
+
+### D1: Env var reading location
+
+**Decision**: Read `FINFOCUS_CACHE_TTL` in `main.go` and set
+`cacheConfig.TTL` before passing to `NewCachedClient`.
+
+**Rationale**: Follows the existing pattern for `FINFOCUS_PLUGIN_PORT`
+(lines 62-77) and `FINFOCUS_LOG_LEVEL` (lines 38-50). Keeps
+`azureclient` package free of env var dependencies (pure library).
+
+**Alternatives rejected**:
+
+- Reading env var inside `DefaultCacheConfig()`: Would couple the
+  library to os.Getenv, making it harder to test and reuse.
+
+### D2: Invalid env var handling
+
+**Decision**: Log a warning with the invalid value and fall back to
+the default 24-hour TTL. Do NOT fail startup.
+
+**Rationale**: Matches the `FINFOCUS_LOG_LEVEL` pattern (lines 44-49)
+where invalid values log a warning and fall back to defaults. A
+misconfigured cache TTL should not prevent the plugin from serving
+cost estimates.
+
+### D3: Eviction callback and reason inference
+
+**Decision**: Register an eviction callback with the LRU constructor.
+The callback receives the evicted key and value. To infer the eviction
+reason, compare `CachedResult.CreatedAt + config.TTL` against
+`time.Now()`:
+
+- If `now >= createdAt + TTL`: reason is "expired"
+- Otherwise: reason is "lru"
+
+**Rationale**: The `golang-lru/v2/expirable` library does not pass an
+eviction reason to the callback. Time-based inference is reliable
+because the library evicts expired entries before LRU candidates.
+
+**Alternatives rejected**:
+
+- Generic "evicted" without reason: Loses the diagnostic value that
+  distinguishes capacity pressure from stale data cleanup.
+- Forking the library to add reason: Over-engineering for a debug log.
+
+### D4: Eviction callback logger access
+
+**Decision**: The eviction callback is a closure that captures the
+`CachedClient`'s logger and config at construction time in
+`NewCachedClient`.
+
+**Rationale**: The callback must have access to the logger and TTL
+config to emit structured logs and infer eviction reason. A closure
+over the `CachedClient` fields is the simplest approach.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/015-cache-completion/quickstart.md
+++ b/specs/015-cache-completion/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Cache Layer Completion
+
+## Configuring Cache TTL
+
+Override the default 24-hour cache TTL via environment variable:
+
+```bash
+# Set cache TTL to 1 hour
+export FINFOCUS_CACHE_TTL=1h
+
+# Disable caching entirely (every request hits Azure API)
+export FINFOCUS_CACHE_TTL=0s
+
+# Use default (24 hours) — just don't set the variable
+unset FINFOCUS_CACHE_TTL
+```
+
+Supported duration formats: `10s`, `5m`, `1h`, `24h`, `500ms`.
+
+Invalid values log a warning and fall back to 24 hours:
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+{"level":"warn","value":"banana","error":"time: invalid duration ...",
+ "message":"invalid FINFOCUS_CACHE_TTL, using default"}
+```
+
+<!-- markdownlint-enable MD013 -->
+
+## Viewing Eviction Logs
+
+Eviction events are logged at **debug** level. Enable debug logging:
+
+```bash
+export FINFOCUS_LOG_LEVEL=debug
+```
+
+Example eviction log entries:
+
+<!-- markdownlint-disable MD013 -->
+
+```json
+{"level":"debug","cache_key":"eastus|standard_b1s|||usd",
+ "eviction_reason":"expired","message":"cache entry evicted"}
+{"level":"debug","cache_key":"westus2|standard_d2s_v3|||usd",
+ "eviction_reason":"lru","message":"cache entry evicted"}
+```
+
+<!-- markdownlint-enable MD013 -->
+
+## Verifying Cache Behavior
+
+Run tests with race detector:
+
+```bash
+make test
+```
+
+Check cache stats in logs (emitted every 1000 requests or 5 minutes):
+
+<!-- markdownlint-disable MD013 -->
+
+```json
+{"level":"info","cache_hits":850,"cache_misses":150,
+ "cache_hit_ratio":0.85,"cache_size":150,"message":"cache stats"}
+```
+
+<!-- markdownlint-enable MD013 -->

--- a/specs/015-cache-completion/research.md
+++ b/specs/015-cache-completion/research.md
@@ -1,0 +1,76 @@
+# Research: Cache Layer Completion
+
+## R1: golang-lru/v2 Eviction Callback API
+
+**Decision**: Use the `onEvict func(key K, value V)` parameter in
+`expirable.NewLRU` constructor.
+
+**Rationale**: The constructor signature is
+`NewLRU[K, V](size int, onEvict func(K, V), ttl time.Duration)`.
+Currently `nil` is passed (cache.go:90). Passing a non-nil function
+enables eviction logging with zero changes to the library.
+
+**Alternatives considered**:
+
+- Custom wrapper around the LRU: Unnecessary complexity; the callback
+  API is sufficient.
+- Polling for evictions: Not supported by the library; callbacks are
+  the intended mechanism.
+
+**Key finding**: The callback fires for both LRU eviction and TTL
+expiry. The library does not pass a reason parameter. Reason must be
+inferred from the entry's age.
+
+## R2: Eviction Reason Inference Accuracy
+
+**Decision**: Compare `CachedResult.CreatedAt + config.TTL` against
+`time.Now()` to classify eviction as "expired" or "lru".
+
+**Rationale**: The `expirable.LRU` library processes TTL evictions
+before LRU evictions during its internal cleanup cycle. When an
+entry is evicted and its age exceeds the TTL, it was a TTL eviction.
+When evicted before TTL expiry, it was displaced by a newer entry
+(LRU).
+
+**Alternatives considered**:
+
+- Always log "evicted" without reason: Loses diagnostic value.
+- Track eviction reason in a separate map: Over-engineering for a
+  debug log.
+
+**Edge case**: An entry could be evicted by LRU at the exact moment
+its TTL expires. In this race, classifying it as "expired" is
+acceptable since the entry would have been evicted by TTL moments
+later anyway.
+
+## R3: Go Duration Parsing for Env Var
+
+**Decision**: Use `time.ParseDuration` from the Go standard library.
+
+**Rationale**: `time.ParseDuration` supports all needed formats
+("10s", "1h", "24h", "500ms") and returns a clear error for invalid
+inputs. This is the idiomatic Go approach.
+
+**Alternatives considered**:
+
+- Custom parser with unit suffixes: Unnecessary when stdlib handles it.
+- Integer-only (seconds): Less flexible; "24h" is more readable than
+  "86400".
+
+**Key finding**: `time.ParseDuration("0s")` returns 0, which triggers
+the existing `disabled` flag in `NewCachedClient` (cache.go:85).
+No special handling needed for the zero-TTL disable case.
+
+## R4: Env Var Naming Convention
+
+**Decision**: Use `FINFOCUS_CACHE_TTL` as specified in issue #13.
+
+**Rationale**: Follows the existing `FINFOCUS_` prefix convention
+established by `FINFOCUS_PLUGIN_PORT` and `FINFOCUS_LOG_LEVEL`.
+The `CACHE_TTL` suffix clearly describes the purpose.
+
+**Alternatives considered**:
+
+- `FINFOCUS_CACHE_EXPIRES_AT_TTL` for the caller-facing TTL: Deferred.
+  Only the internal L1 TTL is user-configurable for now. The L2
+  ExpiresAtTTL is an internal implementation detail.

--- a/specs/015-cache-completion/spec.md
+++ b/specs/015-cache-completion/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Cache Layer Completion (v0.3.0 Gaps)
+
+**Feature Branch**: `015-cache-completion`
+**Created**: 2026-03-03
+**Status**: Complete
+**Input**: Remaining gaps from #13 (TTL env var config) and #15 (eviction logging)
+
+## Context
+
+The CachedClient delivered in #12 already satisfies the majority of
+acceptance criteria for issues #13, #14, and #15. Issue #14 (cache key
+normalization) was verified complete and closed. This spec covers the
+two remaining gaps:
+
+1. **#13 gap**: No environment variable override for cache TTL
+2. **#15 gap**: No structured logging when cache entries are evicted
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Environment Variable TTL Override (Priority: P1)
+
+As an operator deploying the plugin, I want to override the default
+cache TTL via an environment variable so I can tune cache freshness
+without rebuilding the binary. For example, setting a shorter TTL in
+staging environments to validate pricing changes faster, or disabling
+caching entirely for debugging.
+
+**Why this priority**: Operators need runtime configurability without
+code changes. This is the only gap blocking #13 closure.
+
+**Independent Test**: Can be fully tested by setting
+`FINFOCUS_CACHE_TTL` to various values and verifying the cache
+behaves accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FINFOCUS_CACHE_TTL=10s` is set, **When** the plugin
+   starts, **Then** cache entries expire after 10 seconds instead of
+   the default 24 hours.
+2. **Given** `FINFOCUS_CACHE_TTL=0s` is set, **When** the plugin
+   starts, **Then** caching is disabled and every lookup goes to the
+   Azure API.
+3. **Given** `FINFOCUS_CACHE_TTL` is not set, **When** the plugin
+   starts, **Then** the default 24-hour TTL is used.
+4. **Given** `FINFOCUS_CACHE_TTL=banana` (invalid duration), **When**
+   the plugin starts, **Then** an error is logged and the default TTL
+   is used as a fallback.
+
+---
+
+### User Story 2 - Eviction Event Logging (Priority: P2)
+
+As a developer debugging cache behavior, I want to see structured log
+entries when cache entries are evicted (by TTL expiry or LRU overflow)
+so I can understand cache churn and tune capacity or TTL settings.
+
+**Why this priority**: Observability for eviction events completes the
+cache monitoring story. Without it, operators can see hits and misses
+but cannot distinguish between TTL expiry and LRU pressure as causes
+of cache misses. This is the only gap blocking #15 closure.
+
+**Independent Test**: Can be fully tested by configuring a small cache,
+filling it beyond capacity, and verifying eviction log entries appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** the cache is at maximum capacity, **When** a new entry is
+   added causing LRU eviction, **Then** a debug-level log entry is
+   emitted with the evicted key and reason "lru".
+2. **Given** a cached entry whose TTL has expired, **When** the entry
+   is accessed or cleaned up, **Then** a debug-level log entry is
+   emitted with the evicted key and reason "expired".
+3. **Given** the logger is not configured (nop logger), **When**
+   evictions occur, **Then** no performance penalty is incurred from
+   the eviction callback.
+
+---
+
+### Edge Cases
+
+- What happens when `FINFOCUS_CACHE_TTL` is set to a negative
+  duration (e.g., `-5s`)? Should be treated as invalid input with
+  fallback to default.
+- What happens when `FINFOCUS_CACHE_TTL` exceeds the ExpiresAtTTL?
+  The existing overflow protection in CachedClient already caps the
+  caller-facing hint, so no special handling needed.
+- What happens when eviction logging is enabled but the cache is
+  under extremely high throughput? Debug-level logs are only emitted
+  when the logger is configured at debug level, so production
+  deployments at info level incur no overhead.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST read the `FINFOCUS_CACHE_TTL` environment
+  variable at startup and use its value as the internal cache TTL.
+- **FR-002**: System MUST parse the environment variable as a standard
+  duration string (e.g., "10s", "1h", "24h").
+- **FR-003**: System MUST fall back to the default 24-hour TTL when
+  the environment variable is not set or contains an invalid value.
+- **FR-004**: System MUST log a warning when the environment variable
+  contains an invalid duration value, including the invalid value in
+  the log entry.
+- **FR-005**: System MUST log an informational message at startup
+  indicating the effective cache TTL in use.
+- **FR-006**: System MUST emit a debug-level structured log entry when
+  a cache entry is evicted, including the evicted cache key.
+- **FR-007**: System MUST include an eviction reason field in eviction
+  log entries to distinguish LRU eviction from TTL expiry.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Setting `FINFOCUS_CACHE_TTL=1s` causes cache entries to
+  expire within 2 seconds (verifiable in tests).
+- **SC-002**: Setting `FINFOCUS_CACHE_TTL=0s` results in zero cache
+  hits across any number of repeated identical queries.
+- **SC-003**: Eviction events produce structured log entries visible
+  at debug log level containing both the key and reason.
+- **SC-004**: All new functionality passes Go's race detector under
+  concurrent access (`go test -race`).
+- **SC-005**: Existing cache tests continue to pass with no
+  regressions.
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations (>=80%
+  for business logic)
+- [x] Error handling strategy is defined (no silent failures)
+- [x] Code complexity is considered (functions <15 cyclomatic
+  complexity)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then
+  format)
+- [x] Integration test needs identified (external API interactions)
+- [x] Performance test criteria specified (if applicable)
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable
+- [x] Response time expectations defined (cache hits <10ms p99, API
+  calls <2s p95)
+- [x] Observability requirements specified (logging, metrics)
+
+### Documentation
+
+- [x] README.md updates identified (if user-facing changes)
+- [x] API documentation needs outlined (godoc comments, contracts)
+- [x] Docstring coverage >=80% maintained (all exported symbols
+  documented)
+- [x] Examples/quickstart guide planned (if new capability)
+
+### Performance & Reliability
+
+- [x] Performance targets specified (response times, throughput)
+- [x] Reliability requirements defined (retry logic, error handling)
+- [x] Resource constraints considered (memory, connections, cache TTL)
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The `FINFOCUS_CACHE_TTL` environment variable is read once at plugin
+  startup. Changing it requires a plugin restart.
+- The eviction callback provided to the LRU library may be called from
+  any goroutine, so it must be safe for concurrent use (zerolog
+  loggers are already thread-safe).
+- Debug-level eviction logs are acceptable for production since most
+  deployments run at info level, making the callback a no-op in
+  practice.
+- The `golang-lru/v2/expirable` library's eviction callback fires for
+  both LRU and TTL evictions, but does not distinguish between them.
+  The eviction reason may need to be inferred (e.g., by checking if
+  the entry's age exceeds TTL at eviction time).

--- a/specs/015-cache-completion/tasks.md
+++ b/specs/015-cache-completion/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: Cache Layer Completion (v0.3.0 Gaps)
+
+**Input**: Design documents from `/specs/015-cache-completion/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+quickstart.md
+
+**Tests**: Included per constitution (TDD required for all new
+features).
+
+**Organization**: Tasks grouped by user story for independent
+implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story (US1, US2)
+- Exact file paths included in all task descriptions
+
+## Path Conventions
+
+- **Entry point**: `cmd/finfocus-plugin-azure-public/main.go`
+- **Cache library**: `internal/azureclient/cache.go`
+- **Cache tests**: `internal/azureclient/cache_test.go`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project setup needed. Both changes modify existing
+files in an established codebase. This phase is a no-op.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational infrastructure needed. Both user stories
+operate on existing code with no shared new dependencies.
+
+---
+
+## Phase 3: User Story 1 - Environment Variable TTL Override (P1)
+
+**Goal**: Allow operators to override the default 24-hour cache TTL
+via `FINFOCUS_CACHE_TTL` environment variable.
+
+**Independent Test**: Set `FINFOCUS_CACHE_TTL=1s`, start plugin,
+perform a pricing lookup, wait 2 seconds, perform another lookup,
+verify second lookup triggers a fresh API call.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before
+> implementation**
+
+- [x] T001 [US1] Write test for valid `FINFOCUS_CACHE_TTL` parsing
+  (e.g., "10s", "1h") in
+  `cmd/finfocus-plugin-azure-public/main_test.go`
+- [x] T002 [US1] Write test for invalid `FINFOCUS_CACHE_TTL` parsing
+  (e.g., "banana") falling back to default in
+  `cmd/finfocus-plugin-azure-public/main_test.go`
+- [x] T003 [US1] Write test for unset `FINFOCUS_CACHE_TTL` using
+  default 24h TTL in
+  `cmd/finfocus-plugin-azure-public/main_test.go`
+- [x] T004 [US1] Write test for `FINFOCUS_CACHE_TTL=0s` disabling
+  cache in `cmd/finfocus-plugin-azure-public/main_test.go`
+- [x] T005 [US1] Write test for negative duration (e.g., "-5s")
+  falling back to default in
+  `cmd/finfocus-plugin-azure-public/main_test.go`
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Extract a `parseCacheTTL` helper function that reads
+  `FINFOCUS_CACHE_TTL` env var, parses with `time.ParseDuration`,
+  logs warning on invalid value, returns default on error/unset, in
+  `cmd/finfocus-plugin-azure-public/main.go`
+- [x] T007 [US1] Call `parseCacheTTL` and set `cacheConfig.TTL` before
+  `NewCachedClient` call (after line 91) in
+  `cmd/finfocus-plugin-azure-public/main.go`
+- [x] T008 [US1] Log effective cache TTL at info level after cache
+  config is resolved in
+  `cmd/finfocus-plugin-azure-public/main.go`
+
+**Checkpoint**: `FINFOCUS_CACHE_TTL` env var overrides default TTL.
+All T001-T005 tests pass. Plugin logs effective TTL at startup.
+
+---
+
+## Phase 4: User Story 2 - Eviction Event Logging (P2)
+
+**Goal**: Emit debug-level structured logs when cache entries are
+evicted by TTL expiry or LRU overflow.
+
+**Independent Test**: Configure a cache with MaxSize=2, insert 3
+entries, verify a debug log is emitted for the evicted entry with
+the correct key and reason.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before
+> implementation**
+
+- [x] T009 [US2] Write test for LRU eviction callback logging with
+  reason "lru" when cache exceeds capacity in
+  `internal/azureclient/cache_test.go`
+- [x] T010 [US2] Write test for TTL eviction callback logging with
+  reason "expired" when entry ages past TTL in
+  `internal/azureclient/cache_test.go`
+- [x] T011 [US2] Write test verifying eviction callback is safe under
+  concurrent access (`go test -race`) in
+  `internal/azureclient/cache_test.go`
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Replace `nil` eviction callback in
+  `expirable.NewLRU` (cache.go:90) with a closure that logs
+  eviction events at debug level in
+  `internal/azureclient/cache.go`
+- [x] T013 [US2] Implement eviction reason inference in the callback:
+  compare `CachedResult.CreatedAt + config.TTL` vs `time.Now()` to
+  classify as "expired" or "lru" in
+  `internal/azureclient/cache.go`
+- [x] T014 [US2] Include structured log fields: `cache_key` and
+  `eviction_reason` in the eviction callback debug log in
+  `internal/azureclient/cache.go`
+
+**Checkpoint**: Eviction events produce structured debug logs with
+key and reason. All T009-T011 tests pass. Race detector passes.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, documentation, and compliance
+
+### Constitution Compliance Tasks
+
+- [x] T015 [P] Run `make lint` and fix all linting issues
+- [x] T016 [P] Run `go test -race ./...` to verify thread safety
+- [x] T017 [P] Verify test coverage >=80% for modified files
+  (`go test -cover ./internal/azureclient/...
+  ./cmd/finfocus-plugin-azure-public/...`)
+- [x] T018 [P] Add godoc comments to `parseCacheTTL` and any new
+  exported functions
+- [x] T019 [P] Update CLAUDE.md with `FINFOCUS_CACHE_TTL` env var
+  documentation
+- [x] T020 Verify all existing cache tests still pass (no regressions)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Skipped — no new setup needed
+- **Foundational (Phase 2)**: Skipped — no blocking prerequisites
+- **US1 (Phase 3)**: Can start immediately — modifies `main.go` only
+- **US2 (Phase 4)**: Can start immediately — modifies `cache.go` only
+- **Polish (Phase 5)**: Depends on both US1 and US2 completion
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependencies on US2. Modifies `main.go` only.
+- **US2 (P2)**: No dependencies on US1. Modifies `cache.go` and
+  `cache_test.go` only.
+- **US1 and US2 can run in parallel** — they touch different files.
+
+### Within Each User Story
+
+- Tests MUST be written first and FAIL before implementation
+- Implementation tasks are sequential within each story
+- Story complete before moving to Polish phase
+
+### Parallel Opportunities
+
+- US1 (T001-T008) and US2 (T009-T014) can execute in parallel
+  (different files)
+- All T001-T005 tests can be written in parallel
+- T009, T010, T011 tests can be written in parallel
+- All T015-T020 polish tasks marked [P] can run in parallel
+
+---
+
+## Parallel Example: Full Feature
+
+```text
+# Both user stories can run in parallel:
+
+# Stream A (US1 - main.go):
+T001-T005: Write env var tests (parallel)
+T006-T008: Implement env var parsing (sequential)
+
+# Stream B (US2 - cache.go):
+T009-T011: Write eviction callback tests (parallel)
+T012-T014: Implement eviction callback (sequential)
+
+# After both streams complete:
+T015-T020: Polish tasks (parallel where marked [P])
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 3: US1 (env var TTL override)
+2. **STOP and VALIDATE**: Test with `FINFOCUS_CACHE_TTL=1s`
+3. This alone closes issue #13
+
+### Incremental Delivery
+
+1. US1 (env var) -> Test independently -> Closes #13
+2. US2 (eviction logging) -> Test independently -> Closes #15
+3. Polish -> Closes v0.3.0 milestone
+
+### Parallel Strategy
+
+Both stories touch different files and can execute simultaneously:
+
+- Stream A: `main.go` + `main_test.go` (US1)
+- Stream B: `cache.go` + `cache_test.go` (US2)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1 and US2 are fully independent — no cross-story dependencies
+- Commit after each story checkpoint
+- Run `make test` after each story to catch regressions early


### PR DESCRIPTION
…bility

## Summary

- Wire CachedClient into all three gRPC handlers (EstimateCost, GetActualCost, GetProjectedCost) with request-to-query extraction and `expires_at` propagation
- Add configurable cache TTL via `FINFOCUS_CACHE_TTL` env var with validation in `main.go` (supports disable with "0s")
- Bump finfocus-spec to v0.5.7 for `expires_at` fields and pluginsdk response builders
- Debug-level structured eviction logging with `cache_key` and `eviction_reason` fields for cache observability

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] Unit tests for CachedClient (807 lines covering hit/miss, TTL expiry, eviction, stats, Close)
- [x] Unit tests for cache key normalization (80 lines)
- [x] Unit tests for calculator gRPC handlers (229 lines)
- [x] Unit tests for main.go parseCacheTTL (131 lines)

## Changes

### New files

- `internal/azureclient/cache.go` - CachedClient wrapping Client with LRU+TTL, eviction callbacks, and CachedResult with ExpiresAt
- `internal/azureclient/cache_test.go` - Comprehensive cache tests
- `internal/azureclient/cachekey.go` - Normalized cache key builder
- `internal/azureclient/cachekey_test.go` - Key normalization tests
- `internal/pricing/calculator_test.go` - gRPC handler unit tests
- `cmd/finfocus-plugin-azure-public/main_test.go` - TTL parsing tests
- `specs/015-cache-completion/` - Feature spec artifacts

### Modified files

- `internal/pricing/calculator.go` - Wire CachedClient into all three RPC stubs with query extraction helpers
- `cmd/finfocus-plugin-azure-public/main.go` - Build CachedClient, add parseCacheTTL, pass to Calculator
- `internal/azureclient/client.go` - Add Close method, expose Fetcher interface
- `go.mod` / `go.sum` - Add golang-lru/v2, bump finfocus-spec
- `CLAUDE.md` - Document cache API, env vars, architecture
- `README.md` - Add FINFOCUS_CACHE_TTL to env var table

Closes #13
Closes #15