### PR TITLE
feat(pricing): implement GetProjectedCost RPC for VM pricing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,53 @@ size (e.g., 100 GB → P10/128 GiB tier). 14 tiers from 4 GiB to 32767 GiB.
 
 **ZRS pricing**: ZRS disk types use meter names with " ZRS" suffix (e.g., "P10 ZRS").
 
+## GetProjectedCost RPC (`internal/pricing/calculator.go`)
+
+Returns projected monthly cost for Azure resources via `ResourceDescriptor`:
+
+```go
+req := &finfocusv1.GetProjectedCostRequest{
+    Resource: &finfocusv1.ResourceDescriptor{
+        Provider:     "azure",
+        ResourceType: "compute/VirtualMachine",
+        Region:       "eastus",
+        Sku:          "Standard_B1s",
+    },
+}
+
+resp, err := calc.GetProjectedCost(ctx, req)
+// resp.GetUnitPrice()      → 0.0104 (hourly)
+// resp.GetCurrency()       → "USD"
+// resp.GetCostPerMonth()   → 7.592 (0.0104 × 730)
+// resp.GetBillingDetail()  → "Azure Retail Prices API: Standard_B1s in ..."
+// resp.GetPricingCategory() → FOCUS_PRICING_CATEGORY_STANDARD
+// resp.GetExpiresAt()      → cache expiry timestamp
+```
+
+**Supported resource types**:
+
+| Resource Type | Status | Pricing Model |
+| --- | --- | --- |
+| `compute/VirtualMachine` | Supported | Hourly × 730 hrs/mo |
+| `storage/ManagedDisk` | Validates, returns Unimplemented | Monthly retail price |
+| `storage/BlobStorage` | Validates, returns Unimplemented | Per-GB monthly price |
+
+**Error codes**:
+
+- `InvalidArgument`: nil descriptor, missing region/sku
+- `Unimplemented`: unsupported provider/resource type, nil cachedClient, non-VM
+- `NotFound`: no pricing data for region/SKU
+- `ResourceExhausted`, `Unavailable`, `Internal`: Azure API errors
+
+**Validation**: Uses `MapDescriptorToQuery()` with sentinel errors mapped via
+`MapToGRPCStatus()`. Tag fallback: `Tags["region"]` and `Tags["sku"]` when
+primary fields empty. Default currency: USD.
+
+**Logging**: Structured zerolog at all decision points — Info for request
+entry and success (with `cost_monthly`, `currency`, `unit_price`,
+`result_status=success`), Warn for validation failures and nil cachedClient,
+Error for API/cache failures.
+
 ## Environment Variables
 
 <!-- markdownlint-disable MD013 -->

--- a/internal/azureclient/logger.go
+++ b/internal/azureclient/logger.go
@@ -34,7 +34,7 @@ func toFields(keysAndValues []interface{}) map[string]interface{} {
 	fields := make(map[string]interface{})
 	// Loop condition i+1 < len ensures we never access out-of-bounds
 	for i := 0; i+1 < len(keysAndValues); i += 2 {
-		key, ok := keysAndValues[i].(string) //nolint:gosec // G602: bounds checked by loop condition i+1 < len
+		key, ok := keysAndValues[i].(string)
 		if !ok {
 			continue
 		}

--- a/internal/pricing/calculator.go
+++ b/internal/pricing/calculator.go
@@ -411,36 +411,112 @@ func (c *Calculator) GetActualCost(
 	), nil
 }
 
-// GetProjectedCost is a stub that returns Unimplemented status.
-// Azure pricing lookup is not yet implemented.
+// GetProjectedCost returns the projected monthly cost for an Azure resource
+// based on current retail pricing. It uses MapDescriptorToQuery for validation
+// and maps errors to specific gRPC status codes.
+//
+// Supported resource types:
+//   - compute/VirtualMachine: hourly retail price × 730 hrs/mo
+//   - storage/ManagedDisk, storage/BlobStorage: validated but returns Unimplemented
+//
+// Error codes:
+//   - InvalidArgument: nil descriptor, missing region/sku
+//   - Unimplemented: unsupported provider/resource type, nil cachedClient, non-VM types
+//   - NotFound: no pricing data for region/SKU
+//   - ResourceExhausted, Unavailable, Internal: Azure API errors
+//
+// Response fields: unit_price, currency, cost_per_month, billing_detail,
+// pricing_category (STANDARD), expires_at (cache hint).
 func (c *Calculator) GetProjectedCost(
 	ctx context.Context,
 	req *finfocusv1.GetProjectedCostRequest,
 ) (*finfocusv1.GetProjectedCostResponse, error) {
 	log := logging.RequestLogger(ctx, c.logger)
-	log.Info().Msg("handling GetProjectedCost request")
 
-	query, ok := projectedQueryFromRequest(req)
-	if !ok || c.cachedClient == nil {
-		return nil, status.Error(codes.Unimplemented, "not yet implemented")
+	// Validate via MapDescriptorToQuery — returns sentinel errors.
+	query, err := MapDescriptorToQuery(req.GetResource())
+	if err != nil {
+		grpcErr := MapToGRPCStatus(err).Err()
+		log.Warn().
+			Str("result_status", "error").
+			Err(grpcErr).
+			Msg("GetProjectedCost validation failed")
+		return nil, grpcErr
 	}
 
-	cachedResult, err := c.cachedClient.GetPrices(ctx, query)
+	log.Info().
+		Str("region", query.ArmRegionName).
+		Str("sku", query.ArmSkuName).
+		Str("resource_type", query.ServiceName).
+		Msg("handling GetProjectedCost request")
+
+	// Route by service name: only VMs are fully implemented.
+	if query.ServiceName != defaultServiceName {
+		unimplErr := status.Errorf(codes.Unimplemented,
+			"%s cost projection not yet implemented", query.ServiceName)
+		log.Warn().
+			Str("resource_type", query.ServiceName).
+			Str("result_status", "error").
+			Err(unimplErr).
+			Msg("GetProjectedCost unsupported resource type")
+		return nil, unimplErr
+	}
+
+	if c.cachedClient == nil {
+		unimplErr := status.Error(codes.Unimplemented, "not yet implemented")
+		log.Warn().
+			Str("result_status", "error").
+			Err(unimplErr).
+			Msg("GetProjectedCost unavailable")
+		return nil, unimplErr
+	}
+
+	cachedResult, err := c.cachedClient.GetPrices(ctx, *query)
 	if err != nil {
-		return nil, MapToGRPCStatus(err).Err()
+		grpcErr := MapToGRPCStatus(err).Err()
+		log.Error().
+			Str("region", query.ArmRegionName).
+			Str("sku", query.ArmSkuName).
+			Str("resource_type", query.ServiceName).
+			Str("result_status", "error").
+			Err(grpcErr).
+			Msg("GetProjectedCost pricing lookup failed")
+		return nil, grpcErr
 	}
 
 	unitPrice, currency, err := unitPriceAndCurrency(cachedResult.Items)
 	if err != nil {
-		return nil, MapToGRPCStatus(err).Err()
+		grpcErr := MapToGRPCStatus(err).Err()
+		log.Error().
+			Str("region", query.ArmRegionName).
+			Str("sku", query.ArmSkuName).
+			Str("resource_type", query.ServiceName).
+			Str("result_status", "error").
+			Err(grpcErr).
+			Msg("GetProjectedCost response mapping failed")
+		return nil, grpcErr
 	}
 
+	costMonthly := unitPrice * pluginsdk.HoursPerMonth
+	billingDetail := fmt.Sprintf(
+		"Azure Retail Prices API: %s in %s at $%.4f/hr * %.0f hrs/mo",
+		query.ArmSkuName, query.ArmRegionName, unitPrice, pluginsdk.HoursPerMonth,
+	)
+
+	log.Info().
+		Str("region", query.ArmRegionName).
+		Str("sku", query.ArmSkuName).
+		Str("resource_type", query.ServiceName).
+		Float64("cost_monthly", costMonthly).
+		Str("currency", currency).
+		Float64("unit_price", unitPrice).
+		Str("result_status", "success").
+		Msg("GetProjectedCost completed")
+
 	return pluginsdk.NewGetProjectedCostResponse(
-		pluginsdk.WithProjectedCostDetails(
-			unitPrice,
-			currency,
-			unitPrice*pluginsdk.HoursPerMonth,
-			"azure-retail-prices",
+		pluginsdk.WithProjectedCostDetails(unitPrice, currency, costMonthly, billingDetail),
+		pluginsdk.WithProjectedCostPricingCategory(
+			finfocusv1.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
 		),
 		pluginsdk.WithProjectedCostExpiresAt(cachedResult.ExpiresAt),
 	), nil
@@ -523,35 +599,6 @@ func actualQueryFromRequest(req *finfocusv1.GetActualCostRequest) (azureclient.P
 		ServiceName:   firstNonEmptyTag(tags, "service", "serviceName"),
 		ProductName:   firstNonEmptyTag(tags, "product", "productName"),
 		CurrencyCode:  firstNonEmptyTag(tags, "currency", "currencyCode"),
-	}
-	if query.CurrencyCode == "" {
-		query.CurrencyCode = defaultCurrency
-	}
-	if query.ServiceName == "" {
-		query.ServiceName = defaultServiceName
-	}
-	if query.ArmRegionName == "" || query.ArmSkuName == "" {
-		return azureclient.PriceQuery{}, false
-	}
-
-	return query, true
-}
-
-func projectedQueryFromRequest(req *finfocusv1.GetProjectedCostRequest) (azureclient.PriceQuery, bool) {
-	if req == nil || req.GetResource() == nil {
-		return azureclient.PriceQuery{}, false
-	}
-	resource := req.GetResource()
-	if !strings.EqualFold(resource.GetProvider(), "azure") {
-		return azureclient.PriceQuery{}, false
-	}
-
-	query := azureclient.PriceQuery{
-		ArmRegionName: resource.GetRegion(),
-		ArmSkuName:    resource.GetSku(),
-		CurrencyCode:  firstNonEmptyTag(resource.GetTags(), "currency", "currencyCode"),
-		ServiceName:   firstNonEmptyTag(resource.GetTags(), "service", "serviceName"),
-		ProductName:   firstNonEmptyTag(resource.GetTags(), "product", "productName"),
 	}
 	if query.CurrencyCode == "" {
 		query.CurrencyCode = defaultCurrency

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -207,16 +207,28 @@ func TestCalculatorConcurrentRequestsMaintainSeparateTraceIDs(t *testing.T) {
 }
 
 func TestProjectedCostSupported(t *testing.T) {
-	t.Skip("Skipping: GetProjectedCost not implemented yet. Azure pricing lookup requires implementation.")
+	t.Parallel()
 
-	logger := zerolog.Nop()
-	plugin := NewCalculator(logger)
+	server := newPriceServer(t, []azureclient.PriceItem{
+		{
+			ArmRegionName: "eastus",
+			ArmSkuName:    "Standard_B1s",
+			ServiceName:   "Virtual Machines",
+			CurrencyCode:  "USD",
+			RetailPrice:   0.0104,
+		},
+	}, nil)
+	defer server.Close()
+
+	cachedClient := newCalculatorTestCachedClient(t, server.URL)
+	defer cachedClient.Close()
+
+	plugin := NewCalculator(zerolog.Nop(), cachedClient)
 	testPlugin := pluginsdk.NewTestPlugin(t, plugin)
 
-	// Test supported resource
-	resource := pluginsdk.CreateTestResource("aws", "aws:ec2:Instance", map[string]string{
-		"instanceType": "t3.micro",
-		"region":       "us-east-1",
+	resource := pluginsdk.CreateTestResource("azure", "compute/VirtualMachine", map[string]string{
+		"region": "eastus",
+		"sku":    "Standard_B1s",
 	})
 
 	resp := testPlugin.TestProjectedCost(resource, false)
@@ -990,14 +1002,23 @@ func TestGetActualCostReturnsUnimplemented(t *testing.T) {
 	}
 }
 
-// TestGetProjectedCostReturnsUnimplemented verifies GetProjectedCost returns Unimplemented status.
+// TestGetProjectedCostReturnsUnimplemented verifies GetProjectedCost returns
+// Unimplemented status when cachedClient is nil (graceful degradation).
 func TestGetProjectedCostReturnsUnimplemented(t *testing.T) {
 	t.Parallel()
 
-	logger := zerolog.Nop()
-	calc := NewCalculator(logger)
+	calc := NewCalculator(zerolog.Nop()) // no cachedClient
 
-	_, err := calc.GetProjectedCost(context.Background(), &finfocusv1.GetProjectedCostRequest{})
+	req := &finfocusv1.GetProjectedCostRequest{
+		Resource: &finfocusv1.ResourceDescriptor{
+			Provider:     "azure",
+			ResourceType: "compute/VirtualMachine",
+			Region:       "eastus",
+			Sku:          "Standard_B1s",
+		},
+	}
+
+	_, err := calc.GetProjectedCost(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected Unimplemented error, got nil")
 	}
@@ -1092,7 +1113,7 @@ func TestGetProjectedCostSetsExpiresAtFromCache(t *testing.T) {
 	req := &finfocusv1.GetProjectedCostRequest{
 		Resource: &finfocusv1.ResourceDescriptor{
 			Provider:     "azure",
-			ResourceType: "azure:compute/virtualMachine:VirtualMachine",
+			ResourceType: "compute/VirtualMachine",
 			Region:       "eastus",
 			Sku:          "Standard_B1s",
 		},
@@ -1645,6 +1666,348 @@ func TestEstimateCost_Disk_SizeEdgeCases(t *testing.T) {
 			}
 			if math.Abs(resp.GetCostMonthly()-tc.wantCost) > 0.001 {
 				t.Errorf("cost = %.2f, want %.2f", resp.GetCostMonthly(), tc.wantCost)
+			}
+		})
+	}
+}
+
+// --- Phase 2: GetProjectedCost TDD Tests (T004-T007) ---
+
+// T004: Table-driven validation test for GetProjectedCost.
+func TestGetProjectedCost_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		req      *finfocusv1.GetProjectedCostRequest
+		wantCode codes.Code
+		wantMsg  string
+	}{
+		{
+			name:     "nil_request",
+			req:      nil,
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "descriptor is nil",
+		},
+		{
+			name: "nil_descriptor",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: nil,
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "descriptor is nil",
+		},
+		{
+			name: "wrong_provider",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "gcp",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+					Sku:          "Standard_B1s",
+				},
+			},
+			wantCode: codes.Unimplemented,
+			wantMsg:  "unsupported provider",
+		},
+		{
+			name: "unsupported_resource_type",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "network/LoadBalancer",
+					Region:       "eastus",
+					Sku:          "Standard",
+				},
+			},
+			wantCode: codes.Unimplemented,
+			wantMsg:  "unsupported resource type",
+		},
+		{
+			name: "missing_region",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Sku:          "Standard_B1s",
+				},
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "region",
+		},
+		{
+			name: "missing_sku",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+				},
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "sku",
+		},
+		{
+			name: "missing_both_region_and_sku",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+				},
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "region, sku",
+		},
+		{
+			name: "nil_cachedClient",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+					Sku:          "Standard_B1s",
+				},
+			},
+			wantCode: codes.Unimplemented,
+			wantMsg:  "not yet implemented",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			calc := NewCalculator(zerolog.Nop()) // no cachedClient
+			_, err := calc.GetProjectedCost(context.Background(), tc.req)
+			assertStatusCodeContains(t, err, tc.wantCode, tc.wantMsg)
+		})
+	}
+}
+
+// T005: Success response test asserting all response fields.
+func TestGetProjectedCost_Success_VMResponse(t *testing.T) {
+	t.Parallel()
+
+	server := newPriceServer(t, []azureclient.PriceItem{
+		{
+			ArmRegionName: "eastus",
+			ArmSkuName:    "Standard_B1s",
+			ServiceName:   "Virtual Machines",
+			CurrencyCode:  "USD",
+			RetailPrice:   0.0104,
+		},
+	}, nil)
+	defer server.Close()
+
+	cachedClient := newCalculatorTestCachedClient(t, server.URL)
+	defer cachedClient.Close()
+
+	calc := NewCalculator(zerolog.Nop(), cachedClient)
+	req := &finfocusv1.GetProjectedCostRequest{
+		Resource: &finfocusv1.ResourceDescriptor{
+			Provider:     "azure",
+			ResourceType: "compute/VirtualMachine",
+			Region:       "eastus",
+			Sku:          "Standard_B1s",
+		},
+	}
+
+	resp, err := calc.GetProjectedCost(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetProjectedCost() failed: %v", err)
+	}
+
+	// unit_price
+	if math.Abs(resp.GetUnitPrice()-0.0104) > 0.000001 {
+		t.Errorf("unit_price = %.6f, want 0.0104", resp.GetUnitPrice())
+	}
+
+	// currency
+	if resp.GetCurrency() != "USD" {
+		t.Errorf("currency = %q, want USD", resp.GetCurrency())
+	}
+
+	// cost_per_month = unit_price * 730
+	wantMonthly := 0.0104 * 730.0
+	if math.Abs(resp.GetCostPerMonth()-wantMonthly) > 0.001 {
+		t.Errorf("cost_per_month = %.4f, want %.4f", resp.GetCostPerMonth(), wantMonthly)
+	}
+
+	// billing_detail (exact format)
+	wantDetail := "Azure Retail Prices API: Standard_B1s in eastus at $0.0104/hr * 730 hrs/mo"
+	if resp.GetBillingDetail() != wantDetail {
+		t.Errorf("billing_detail = %q, want %q", resp.GetBillingDetail(), wantDetail)
+	}
+
+	// pricing_category
+	if resp.GetPricingCategory() != finfocusv1.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD {
+		t.Errorf("pricing_category = %v, want STANDARD", resp.GetPricingCategory())
+	}
+
+	// expires_at
+	if resp.GetExpiresAt() == nil {
+		t.Error("expires_at should not be nil")
+	}
+}
+
+// T007: API error propagation test.
+func TestGetProjectedCost_APIError(t *testing.T) {
+	t.Parallel()
+
+	// Server returns empty results → ErrNotFound → codes.NotFound
+	server := newPriceServer(t, []azureclient.PriceItem{}, nil)
+	defer server.Close()
+
+	cachedClient := newCalculatorTestCachedClient(t, server.URL)
+	defer cachedClient.Close()
+
+	calc := NewCalculator(zerolog.Nop(), cachedClient)
+	req := &finfocusv1.GetProjectedCostRequest{
+		Resource: &finfocusv1.ResourceDescriptor{
+			Provider:     "azure",
+			ResourceType: "compute/VirtualMachine",
+			Region:       "eastus",
+			Sku:          "Definitely_Not_A_Real_SKU",
+		},
+	}
+
+	_, err := calc.GetProjectedCost(context.Background(), req)
+	assertStatusCodeContains(t, err, codes.NotFound)
+}
+
+// --- Phase 3: GetProjectedCost Logging Tests (T015a) ---
+
+// T015a: Table-driven logging test for GetProjectedCost.
+func TestGetProjectedCost_Logging(t *testing.T) {
+	t.Parallel()
+
+	type logTestCase struct {
+		name       string
+		items      []azureclient.PriceItem // nil means no cachedClient
+		req        *finfocusv1.GetProjectedCostRequest
+		wantLevel  string
+		wantStatus string
+		wantFields []string
+	}
+
+	tests := []logTestCase{
+		{
+			name: "success_logs_info_with_cost_fields",
+			items: []azureclient.PriceItem{
+				{
+					ArmRegionName: "eastus",
+					ArmSkuName:    "Standard_B1s",
+					ServiceName:   "Virtual Machines",
+					CurrencyCode:  "USD",
+					RetailPrice:   0.0104,
+				},
+			},
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+					Sku:          "Standard_B1s",
+				},
+			},
+			wantLevel:  "info",
+			wantStatus: "success",
+			wantFields: []string{"cost_monthly", "currency", "unit_price"},
+		},
+		{
+			name: "validation_failure_logs_warn",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+				},
+			},
+			wantLevel:  "warn",
+			wantStatus: "error",
+		},
+		{
+			name:  "api_failure_logs_error",
+			items: []azureclient.PriceItem{}, // empty → NotFound
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+					Sku:          "Nonexistent_SKU",
+				},
+			},
+			wantLevel:  "error",
+			wantStatus: "error",
+			wantFields: []string{"region", "sku", "resource_type"},
+		},
+		{
+			name: "nil_cachedClient_logs_warn",
+			req: &finfocusv1.GetProjectedCostRequest{
+				Resource: &finfocusv1.ResourceDescriptor{
+					Provider:     "azure",
+					ResourceType: "compute/VirtualMachine",
+					Region:       "eastus",
+					Sku:          "Standard_B1s",
+				},
+			},
+			wantLevel:  "warn",
+			wantStatus: "error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf)
+
+			var calc *Calculator
+			if tc.items != nil {
+				server := newPriceServer(t, tc.items, nil)
+				defer server.Close()
+				cachedClient := newCalculatorTestCachedClient(t, server.URL)
+				defer cachedClient.Close()
+				calc = NewCalculator(logger, cachedClient)
+			} else {
+				calc = NewCalculator(logger)
+			}
+
+			_, _ = calc.GetProjectedCost(context.Background(), tc.req)
+
+			logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+			var found bool
+			for _, line := range logLines {
+				if line == "" {
+					continue
+				}
+				var entry map[string]any
+				if err := json.Unmarshal([]byte(line), &entry); err != nil {
+					continue
+				}
+				rs, ok := entry["result_status"].(string)
+				if !ok {
+					continue
+				}
+				if rs != tc.wantStatus {
+					continue
+				}
+				found = true
+
+				if lvl, ok := entry["level"].(string); ok && lvl != tc.wantLevel {
+					t.Errorf("expected log level %q, got %q", tc.wantLevel, lvl)
+				}
+
+				for _, field := range tc.wantFields {
+					if _, exists := entry[field]; !exists {
+						t.Errorf("expected field %q in log entry, got: %v", field, entry)
+					}
+				}
+				break
+			}
+
+			if !found {
+				t.Errorf("expected log entry with result_status=%q, log output: %s", tc.wantStatus, buf.String())
 			}
 		})
 	}

--- a/specs/023-projected-cost-rpc/checklists/requirements.md
+++ b/specs/023-projected-cost-rpc/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: GetProjectedCost RPC
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references internal function names (MapDescriptorToQuery, MapToGRPCStatus)
+  in requirements as domain vocabulary — these are established concepts in the project
+  domain, not implementation prescriptions.
+- The "Examples/quickstart guide planned" documentation item is unchecked because
+  this feature enhances an existing RPC rather than adding a new user-facing capability.

--- a/specs/023-projected-cost-rpc/contracts/projected-cost-contract.md
+++ b/specs/023-projected-cost-rpc/contracts/projected-cost-contract.md
@@ -1,0 +1,75 @@
+# API Contract: GetProjectedCost RPC
+
+**Branch**: `023-projected-cost-rpc` | **Date**: 2026-04-04
+
+## Proto Definition (finfocus-spec v0.5.7)
+
+The proto is defined in the `finfocus-spec` repository. This document
+captures the behavioral contract for the Azure plugin implementation.
+
+## Request Contract
+
+```text
+GetProjectedCost(GetProjectedCostRequest) → GetProjectedCostResponse
+
+Required input (via ResourceDescriptor):
+  - provider:      "azure" (case-insensitive, required)
+  - resource_type: "compute/VirtualMachine" (case-insensitive, required)
+  - region:        Azure region name (e.g., "eastus", required)
+  - sku:           Azure SKU name (e.g., "Standard_B1s", required)
+
+Optional input (via ResourceDescriptor.tags):
+  - currency/currencyCode: Currency code (default: "USD")
+  - service/serviceName:   Azure service name (default: per resource type)
+  - product/productName:   Azure product name (optional filter)
+```
+
+## Response Contract
+
+### Success (VM resource type)
+
+```text
+unit_price:       Hourly retail price from Azure API (float64)
+currency:         Currency code from API response (string, e.g., "USD")
+cost_per_month:   unit_price × 730 (float64)
+billing_detail:   "Azure Retail Prices API: {SKU} in {region} at
+                   ${unit_price}/hr * 730 hrs/mo" (string)
+pricing_category: FOCUS_PRICING_CATEGORY_STANDARD (enum)
+expires_at:       Cache expiry timestamp from CachedResult (Timestamp)
+```
+
+### Error Responses
+
+| Condition                 | gRPC Code        | Error Message Pattern                         |
+| ------------------------- | ---------------- | --------------------------------------------- |
+| nil resource descriptor   | InvalidArgument  | "missing required fields: descriptor is nil"  |
+| provider != "azure"       | Unimplemented    | "unsupported provider: {provider}: ..."       |
+| unknown resource type     | Unimplemented    | "unsupported resource type: {type}: ..."      |
+| missing region            | InvalidArgument  | "missing required fields: region"             |
+| missing sku               | InvalidArgument  | "missing required fields: sku"                |
+| missing region + sku      | InvalidArgument  | "missing required fields: region, sku"        |
+| nil cachedClient          | Unimplemented    | "not yet implemented"                         |
+| Azure API not found       | NotFound         | Query context + "not found"                   |
+| Azure API rate limited    | ResourceExhausted| Query context + rate limit details            |
+| Azure API unavailable     | Unavailable      | Query context + service unavailable           |
+| Azure API other error     | Internal         | Query context + error details                 |
+| context canceled          | Canceled         | Context cancellation message                  |
+| context deadline exceeded | DeadlineExceeded | Deadline exceeded message                     |
+
+## Logging Contract
+
+| Event              | Level | Required Fields                                              |
+| ------------------ | ----- | ------------------------------------------------------------ |
+| Request entry      | Info  | region, sku, resource_type, provider                         |
+| Success            | Info  | region, sku, resource_type, cost_monthly, currency, unit_price, result_status=success |
+| Validation failure | Warn  | resource_type (if available), result_status=error, error     |
+| API/cache failure  | Error | region, sku, resource_type, result_status=error, error       |
+| Cache unavailable  | Warn  | result_status=error, error                                   |
+
+## Performance Contract
+
+| Scenario       | Target         |
+| -------------- | -------------- |
+| Cache hit      | < 10ms (p99)   |
+| Cache miss     | < 2s (p95)     |
+| Cache miss     | < 5s (p99)     |

--- a/specs/023-projected-cost-rpc/data-model.md
+++ b/specs/023-projected-cost-rpc/data-model.md
@@ -1,0 +1,95 @@
+# Data Model: GetProjectedCost RPC
+
+**Branch**: `023-projected-cost-rpc` | **Date**: 2026-04-04
+
+## Entities
+
+### GetProjectedCostRequest (Input — proto-defined)
+
+| Field                    | Type               | Required | Description                         |
+| ------------------------ | ------------------ | -------- | ----------------------------------- |
+| resource                 | ResourceDescriptor | Yes      | Target Azure resource to price      |
+| utilization_percentage   | double             | No       | Utilization factor (future use)     |
+| growth_type              | GrowthType         | No       | Growth projection model (future)    |
+| growth_rate              | double (optional)  | No       | Growth rate percentage (future)     |
+| dry_run                  | bool               | No       | Dry run mode flag (future)          |
+| usage_profile            | UsageProfile       | No       | Usage profile override (future)     |
+
+### ResourceDescriptor (Input �� proto-defined)
+
+| Field         | Type              | Required | Validation Rule                               |
+| ------------- | ----------------- | -------- | --------------------------------------------- |
+| provider      | string            | Yes      | Must be "azure" (case-insensitive)            |
+| resource_type | string            | Yes      | Must be in supported set (see below)          |
+| region        | string            | Yes      | Falls back to Tags["region"] if empty         |
+| sku           | string            | Yes      | Falls back to Tags["sku"] if empty            |
+| tags          | map<string,string> | No      | Fallback for region, sku, currency, service   |
+
+**Supported resource types**:
+
+- `compute/VirtualMachine` → full cost computation (this feature)
+- `storage/ManagedDisk` → validates but returns Unimplemented (future)
+- `storage/BlobStorage` → validates but returns Unimplemented (future)
+
+### PriceQuery (Internal — maps from ResourceDescriptor)
+
+| Field         | Source                              | Default           |
+| ------------- | ----------------------------------- | ----------------- |
+| ArmRegionName | resource.Region or Tags["region"]   | (required)        |
+| ArmSkuName    | resource.Sku or Tags["sku"]         | (required)        |
+| ServiceName   | resourceTypeToService lookup        | "Virtual Machines"|
+| CurrencyCode  | Tags["currency"] or Tags["currencyCode"] | "USD"        |
+
+### GetProjectedCostResponse (Output — proto-defined)
+
+| Field              | Type                  | Set By        | Description                                      |
+| ------------------ | --------------------- | ------------- | ------------------------------------------------ |
+| unit_price         | double                | This feature  | Hourly retail price from Azure API               |
+| currency           | string                | This feature  | Currency code (e.g., "USD")                      |
+| cost_per_month     | double                | This feature  | unit_price × 730                                 |
+| billing_detail     | string                | This feature  | Human-readable pricing explanation               |
+| pricing_category   | FocusPricingCategory  | This feature  | FOCUS_PRICING_CATEGORY_STANDARD                  |
+| expires_at         | Timestamp             | Already done  | Cache expiry hint from CachedResult.ExpiresAt    |
+| impact_metrics     | ImpactMetric[]        | Future        | Not set in this feature                          |
+| growth_type        | GrowthType            | Future        | Not set in this feature                          |
+| dry_run_result     | DryRunResponse        | Future        | Not set in this feature                          |
+| spot_interruption  | double                | Future        | Not set in this feature                          |
+| prediction_interval| double (optional pair)| Future        | Not set in this feature                          |
+| confidence_level   | double (optional)     | Future        | Not set in this feature                          |
+
+## Relationships
+
+```text
+GetProjectedCostRequest
+  └── ResourceDescriptor
+        │
+        ├── MapDescriptorToQuery() ──→ PriceQuery
+        │                                  │
+        │                                  ▼
+        │                           CachedClient.GetPrices()
+        │                                  │
+        │                                  ▼
+        │                           CachedResult { Items, ExpiresAt }
+        │                                  │
+        │                                  ▼
+        │                           unitPriceAndCurrency()
+        │                                  │
+        └──────────────────────────────────▼
+                                    GetProjectedCostResponse
+```
+
+## Error Flow
+
+```text
+nil request/descriptor ──→ ErrMissingRequiredFields ──→ InvalidArgument
+wrong provider ──────────→ ErrUnsupportedResourceType ─→ Unimplemented (via MapToGRPCStatus)
+unknown resource type ───→ ErrUnsupportedResourceType ─→ Unimplemented
+missing region/sku ──��───→ ErrMissingRequiredFields ───→ InvalidArgument
+nil cachedClient ────────→ (guard check) ──────────────→ Unimplemented
+API failure ─────��───────→ azureclient errors ─────────→ MapToGRPCStatus()
+empty price list ────────→ ErrNotFound ────────────────→ NotFound
+```
+
+## State Transitions
+
+N/A — stateless request-response. No entity lifecycle.

--- a/specs/023-projected-cost-rpc/plan.md
+++ b/specs/023-projected-cost-rpc/plan.md
@@ -1,0 +1,206 @@
+# Implementation Plan: GetProjectedCost RPC
+
+**Branch**: `023-projected-cost-rpc` | **Date**: 2026-04-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/023-projected-cost-rpc/spec.md`
+
+## Summary
+
+Promote `GetProjectedCost` from a partial stub to a production-ready RPC by
+replacing the boolean-return validation in `projectedQueryFromRequest()` with
+`MapDescriptorToQuery()` (sentinel errors → gRPC codes), adding structured
+zerolog logging at all decision points, and populating `billing_detail` and
+`pricing_category` in the response. Only the VM cost path is fully
+implemented; disk/blob pass validation but return Unimplemented.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.7
+**Primary Dependencies**: finfocus-spec v0.5.7 (pluginsdk), zerolog v1.34.0, google.golang.org/grpc, golang-lru/v2 (cache)
+**Storage**: N/A — stateless plugin (in-memory LRU+TTL cache only)
+**Testing**: Go standard `testing` package, table-driven tests, `httptest` for mock servers
+**Target Platform**: Linux container (gRPC server)
+**Project Type**: Single Go project
+**Performance Goals**: Cache hit <10ms p99, cache miss <2s p95
+**Constraints**: No authenticated Azure APIs, no persistent storage, no infrastructure mutation
+**Scale/Scope**: ~150 lines of production code changes, ~200 lines of test additions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with `.specify/memory/constitution.md`:
+
+- [x] **Code Quality**: Plan uses existing `MapDescriptorToQuery()` for validation (no new complexity), `MapToGRPCStatus()` for error mapping, structured logging via zerolog. Linting via `make lint`.
+- [x] **Testing**: Plan follows TDD — tests written first for all error paths and success path. ≥80% coverage target. No concurrent code changes (cache layer is pre-existing and tested).
+- [x] **User Experience**: Error messages include specific field names. All gRPC status codes are consistent with `EstimateCost` pattern. Structured logging at Info/Warn/Error levels.
+- [x] **Documentation**: Godoc comments updated for refactored functions. CLAUDE.md updated with GetProjectedCost section. README updates for supported resource types.
+- [x] **Performance**: No new performance concerns — reuses existing cached client and mapper. Response times bounded by cache TTL (24h default).
+- [x] **Architectural Constraints**: DOES NOT introduce authenticated APIs, persistent storage, infrastructure mutation, or bulk data embedding. Uses existing unauthenticated Azure Retail Prices API client.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-projected-cost-rpc/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research findings
+├── data-model.md        # Phase 1 entity model
+├── quickstart.md        # Phase 1 usage guide
+├── contracts/
+│   └── projected-cost-contract.md  # Behavioral contract
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+internal/pricing/
+├── calculator.go        # GetProjectedCost() refactored + projectedQueryFromRequest() removed
+├── calculator_test.go   # New test cases + existing test fixture update
+├── mapper.go            # No changes (MapDescriptorToQuery already sufficient)
+├── errors.go            # No changes (MapToGRPCStatus already maps all sentinels)
+└── ...                  # Other files unchanged
+```
+
+**Structure Decision**: All changes are within the existing `internal/pricing`
+package. No new files or packages needed. The refactoring simplifies the
+code by removing `projectedQueryFromRequest()` and replacing it with the
+existing `MapDescriptorToQuery()`.
+
+## Implementation Design
+
+### Phase 2: Task Decomposition
+
+#### Task 1: Write Tests for Validation Error Paths (TDD Red)
+
+Write failing tests for all validation scenarios before changing production
+code. Table-driven test covering:
+
+- Nil request → InvalidArgument
+- Nil resource descriptor → InvalidArgument
+- Wrong provider ("gcp") → Unimplemented (via ErrUnsupportedResourceType)
+- Unsupported resource type ("network/LoadBalancer") → Unimplemented
+- Missing region → InvalidArgument with "region" in message
+- Missing SKU → InvalidArgument with "sku" in message
+- Missing both region and SKU → InvalidArgument with both in message
+- Nil cachedClient → Unimplemented
+- Valid VM request → success with all response fields
+
+**File**: `internal/pricing/calculator_test.go`
+**Depends on**: Nothing
+
+#### Task 2: Refactor GetProjectedCost to Use MapDescriptorToQuery (TDD Green)
+
+Replace `projectedQueryFromRequest()` usage with direct
+`MapDescriptorToQuery()` call. Handle the refactoring in this order:
+
+1. Extract resource descriptor from request (nil check)
+2. Call `MapDescriptorToQuery(req.GetResource())` for validation
+3. Map returned errors via `MapToGRPCStatus()`
+4. Guard on nil cachedClient
+5. Route by resource type: VM computes cost, disk/blob return Unimplemented
+6. Call `cachedClient.GetPrices()` → `unitPriceAndCurrency()`
+7. Build response with `WithProjectedCostDetails()`,
+   `WithProjectedCostPricingCategory()`, `WithProjectedCostExpiresAt()`
+
+**File**: `internal/pricing/calculator.go`
+**Depends on**: Task 1 (tests exist to validate)
+
+#### Task 3: Add Structured Logging
+
+Add zerolog structured logging at all decision points, matching the
+`EstimateCost` pattern:
+
+- Request entry: Info with region, sku, resource_type, provider
+- Validation failure: Warn with result_status=error
+- cachedClient nil: Warn with result_status=error
+- API/cache failure: Error with result_status=error
+- Success: Info with cost_monthly, currency, unit_price, result_status=success
+
+**Files**: `internal/pricing/calculator_test.go` (TDD test), `internal/pricing/calculator.go` (implementation)
+**Depends on**: Task 2 (refactored method exists). TDD: write logging test first (capturing zerolog output), then implement logging.
+
+#### Task 4: Update Existing Test Fixtures
+
+Update `TestGetProjectedCostSetsExpiresAtFromCache` to use correct
+resource type format: `"compute/VirtualMachine"` instead of
+`"azure:compute/virtualMachine:VirtualMachine"`.
+
+Also rewrite `TestProjectedCostSupported` to use Azure provider and
+resource type (`provider="azure"`, `resource_type="compute/VirtualMachine"`,
+`region="eastus"`, `sku="Standard_B1s"`) instead of the current AWS
+placeholder data, and remove the `t.Skip()` call.
+
+**File**: `internal/pricing/calculator_test.go`
+**Depends on**: Task 2 (refactored method handles resource type)
+
+#### Task 5: Remove projectedQueryFromRequest Function
+
+After all tests pass with the new implementation, remove the now-unused
+`projectedQueryFromRequest()` function. Verify no other callers exist.
+
+**File**: `internal/pricing/calculator.go`
+**Depends on**: Tasks 2, 4 (all callers migrated)
+
+#### Task 6: Update Documentation
+
+- Update CLAUDE.md with GetProjectedCost section (response fields,
+  supported resource types, error codes)
+- Verify godoc comments on refactored functions
+- Run `make lint` to validate
+
+**Files**: `CLAUDE.md`, `internal/pricing/calculator.go`
+**Depends on**: Task 5 (implementation finalized)
+
+#### Task 7: Quality Gates
+
+- `make build` succeeds
+- `make test` passes (all tests including race detector)
+- `make lint` passes
+- Verify docstring coverage ≥80%
+
+**Depends on**: All previous tasks
+
+### Dependency Graph
+
+```text
+Task 1 (Tests) ──→ Task 2 (Refactor) ──→ Task 3 (Logging) ──→ Task 5 (Cleanup)
+                         │                                          │
+                         └──→ Task 4 (Fix fixtures) ───────────────┘
+                                                                    │
+                                                              Task 6 (Docs)
+                                                                    │
+                                                              Task 7 (Gates)
+```
+
+## Key Design Decisions
+
+### D1: Remove projectedQueryFromRequest Instead of Wrapping
+
+The function currently duplicates validation logic from `MapDescriptorToQuery()`.
+Rather than making it a thin wrapper, remove it entirely and call the mapper
+directly. This eliminates a layer of indirection and a potential source of
+divergence.
+
+### D2: Resource Type Routing After Validation
+
+After `MapDescriptorToQuery()` succeeds, check the resolved service name:
+- `"Virtual Machines"` → compute cost (hourly × 730)
+- `"Managed Disks"` / `"Storage"` → return Unimplemented with descriptive message
+
+This ensures disk/blob requests get clear feedback ("storage/ManagedDisk cost
+projection not yet implemented") rather than silent failures.
+
+### D3: billing_detail Format
+
+Use the format from the issue example:
+`"Azure Retail Prices API: Standard_B1s in eastus at $0.0104/hr * 730 hrs/mo"`
+
+This provides: data source, SKU, region, unit rate, and calculation method.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/023-projected-cost-rpc/quickstart.md
+++ b/specs/023-projected-cost-rpc/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: GetProjectedCost RPC
+
+**Branch**: `023-projected-cost-rpc` | **Date**: 2026-04-04
+
+## Overview
+
+`GetProjectedCost` returns the projected monthly cost for an Azure resource
+based on current retail pricing. It uses the `ResourceDescriptor` proto
+message to identify the resource and queries the Azure Retail Prices API
+(via a cached client) for live pricing data.
+
+## Usage (Go client)
+
+```go
+import (
+    finfocusv1 "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+)
+
+// Build the request
+req := &finfocusv1.GetProjectedCostRequest{
+    Resource: &finfocusv1.ResourceDescriptor{
+        Provider:     "azure",
+        ResourceType: "compute/VirtualMachine",
+        Region:       "eastus",
+        Sku:          "Standard_B1s",
+    },
+}
+
+// Call the RPC
+resp, err := client.GetProjectedCost(ctx, req)
+if err != nil {
+    // Handle gRPC status error
+    st, _ := status.FromError(err)
+    switch st.Code() {
+    case codes.InvalidArgument:
+        // Missing or invalid fields — check st.Message() for details
+    case codes.Unimplemented:
+        // Resource type not supported yet
+    case codes.NotFound:
+        // No pricing data for this region/SKU
+    default:
+        // Other error (rate limited, unavailable, etc.)
+    }
+    return err
+}
+
+// Access response fields
+fmt.Printf("Monthly cost: %s %.2f\n", resp.GetCurrency(), resp.GetCostPerMonth())
+fmt.Printf("Unit price:   %s %.4f/hr\n", resp.GetCurrency(), resp.GetUnitPrice())
+fmt.Printf("Detail:       %s\n", resp.GetBillingDetail())
+fmt.Printf("Category:     %s\n", resp.GetPricingCategory())
+fmt.Printf("Expires at:   %s\n", resp.GetExpiresAt().AsTime())
+```
+
+## Supported Resource Types
+
+| Resource Type             | Status        | Pricing Model         |
+| ------------------------- | ------------- | --------------------- |
+| compute/VirtualMachine    | Supported     | Hourly × 730 hrs/mo  |
+| storage/ManagedDisk       | Planned       | Monthly retail price  |
+| storage/BlobStorage       | Planned       | Per-GB monthly price  |
+
+## Error Handling
+
+All errors are returned as gRPC status codes with descriptive messages.
+Missing fields are reported in a single error (e.g., "missing required
+fields: region, sku").
+
+## Caching
+
+Responses include an `expires_at` timestamp indicating when the cached
+pricing data will be refreshed. Cache TTL defaults to 24 hours and can
+be configured via the `FINFOCUS_CACHE_TTL` environment variable.

--- a/specs/023-projected-cost-rpc/research.md
+++ b/specs/023-projected-cost-rpc/research.md
@@ -1,0 +1,97 @@
+# Research: GetProjectedCost RPC Implementation
+
+**Branch**: `023-projected-cost-rpc` | **Date**: 2026-04-04
+
+## R1: Refactoring projectedQueryFromRequest to use MapDescriptorToQuery
+
+**Decision**: Replace the boolean-return `projectedQueryFromRequest()` with
+a call to `MapDescriptorToQuery()` which returns sentinel errors.
+
+**Rationale**: `MapDescriptorToQuery()` already validates provider,
+resource type, region, and SKU with proper sentinel errors
+(`ErrUnsupportedResourceType`, `ErrMissingRequiredFields`) that map to gRPC
+codes via `MapToGRPCStatus()`. The current `projectedQueryFromRequest()`
+duplicates validation logic and discards error context by returning a boolean.
+
+**Alternatives considered**:
+
+- Keep `projectedQueryFromRequest()` but add error returns: Rejected because
+  it would duplicate validation logic already in `MapDescriptorToQuery()`.
+- Call `MapDescriptorToQuery()` inside `projectedQueryFromRequest()`: Viable
+  but adds unnecessary indirection. Better to call the mapper directly in
+  `GetProjectedCost()`.
+
+## R2: Resource Type URN Format in Existing Test
+
+**Decision**: Update the existing test fixture
+`TestGetProjectedCostSetsExpiresAtFromCache` to use short-form resource type
+`"compute/VirtualMachine"` instead of full URN
+`"azure:compute/virtualMachine:VirtualMachine"`.
+
+**Rationale**: The mapper performs `strings.ToLower(desc.GetResourceType())`
+and does a direct lookup against keys like `"compute/virtualmachine"`. The
+full URN format does not match. The existing test only passes because the
+current code ignores the resource type field entirely. This is a test data
+fix, not a behavioral change.
+
+**Alternatives considered**:
+
+- Add URN parsing to the mapper: Rejected because `ResourceDescriptor.ResourceType`
+  is defined as the type segment, not the full Pulumi URN. Changing the
+  mapper's contract for a test fixture issue is overengineering.
+- Add URN stripping in `GetProjectedCost()`: Rejected — same reason as above.
+
+## R3: Resource Type Routing (VM vs Disk/Blob)
+
+**Decision**: For this feature, only implement the full projected cost path
+for VMs (`compute/VirtualMachine`). Disk and Blob Storage pass mapper
+validation but return `codes.Unimplemented` with a descriptive message at
+the resource-type routing level.
+
+**Rationale**: VMs use hourly pricing (unit_price × 730 = monthly cost).
+Disks use monthly pricing directly. Blob Storage has a different pricing
+model entirely. Implementing all three would significantly expand scope
+beyond issue #59. The mapper validates the type is "known" but the cost
+computation path is VM-specific.
+
+**Alternatives considered**:
+
+- Implement all three in this feature: Rejected — scope creep beyond issue #59.
+- Block disk/blob at the mapper level: Rejected — the mapper correctly
+  identifies them as "known" types. The routing decision belongs in the RPC
+  handler.
+
+## R4: billing_detail Format
+
+**Decision**: Use format
+`"Azure Retail Prices API: {SKU} in {region} at ${unit_price}/hr * 730 hrs/mo"`
+matching the `EstimateCost` pattern.
+
+**Rationale**: The `WithProjectedCostDetails()` pluginsdk helper accepts a
+`billingDetail string` parameter. The format should be human-readable and
+include enough context for debugging. The issue example shows this exact
+pattern.
+
+**Alternatives considered**:
+
+- Machine-parseable JSON: Rejected — `billing_detail` is documented as
+  informational; structured data belongs in dedicated response fields.
+- Include cache status: Rejected — cache is transparent to consumers.
+
+## R5: pluginsdk Response Option Composition
+
+**Decision**: Use `WithProjectedCostDetails()` for core fields,
+`WithProjectedCostPricingCategory()` for pricing category, and
+`WithProjectedCostExpiresAt()` for cache expiry.
+
+**Rationale**: The pluginsdk provides functional option helpers that compose
+cleanly. `WithProjectedCostDetails()` sets unit_price, currency,
+cost_per_month, and billing_detail in a single call.
+`WithProjectedCostPricingCategory()` is a separate option since it's an enum
+value, not a string/float. This matches how `EstimateCost` uses
+`WithEstimateCost()` + `WithPricingCategory()`.
+
+**Alternatives considered**:
+
+- Set response fields directly without helpers: Rejected — pluginsdk helpers
+  are the established pattern and include validation.

--- a/specs/023-projected-cost-rpc/spec.md
+++ b/specs/023-projected-cost-rpc/spec.md
@@ -1,0 +1,295 @@
+# Feature Specification: Implement GetProjectedCost RPC
+
+**Feature Branch**: `023-projected-cost-rpc`
+**Created**: 2026-04-04
+**Status**: Draft
+**Input**: GitHub Issue #59 — Promote GetProjectedCost partial implementation to production-ready RPC
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Projected VM Cost Lookup (Priority: P1)
+
+A FinFocus platform consumer sends a `GetProjectedCost` request with a valid
+Azure VM resource descriptor (provider, region, SKU, resource type). The system
+queries Azure Retail Prices (via cached client), computes projected monthly cost,
+and returns a complete response including unit price, currency, monthly cost,
+a human-readable billing explanation, pricing category, and a cache expiry hint.
+
+**Why this priority**: This is the primary happy path — a correctly-formed VM
+request returning a fully populated response. Every other behavior depends on
+this working first.
+
+**Independent Test**: Can be fully tested by sending a valid
+`GetProjectedCostRequest` with `provider=azure`, `region=eastus`,
+`sku=Standard_B1s`, `resource_type=compute/VirtualMachine` and asserting all
+response fields are populated with correct values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Calculator with a cached client that has Azure pricing data,
+   **When** a request with provider "azure", region "eastus", SKU
+   "Standard_B1s", and resource type "compute/VirtualMachine" is received,
+   **Then** the response includes `unit_price` (hourly rate), `currency`
+   ("USD"), `cost_per_month` (unit_price × 730), `billing_detail` with a
+   human-readable explanation, and `pricing_category` set to STANDARD.
+
+2. **Given** a Calculator with a cached client,
+   **When** a valid projected cost request is made,
+   **Then** the response includes an `expires_at` timestamp propagated from
+   the cache layer's `ExpiresAt` field.
+
+---
+
+### User Story 2 - Validation Error Feedback (Priority: P1)
+
+A consumer sends a `GetProjectedCost` request with missing or incorrect fields.
+The system returns a specific gRPC error code with a message identifying exactly
+which fields are missing or which values are invalid, rather than a generic
+"Unimplemented" response.
+
+**Why this priority**: Clear error feedback is essential for consumer
+integration. Without it, callers cannot distinguish between "this feature
+doesn't exist" and "you sent bad input."
+
+**Independent Test**: Can be tested by sending requests with various
+combinations of missing/invalid fields and asserting the correct gRPC code
+and field names appear in the error message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Calculator with a cached client,
+   **When** a request is received with an empty region field,
+   **Then** the system returns `InvalidArgument` with "region" in the error
+   message.
+
+2. **Given** a Calculator with a cached client,
+   **When** a request is received with an empty SKU field,
+   **Then** the system returns `InvalidArgument` with "sku" in the error
+   message.
+
+3. **Given** a Calculator with a cached client,
+   **When** a request is received with both region and SKU missing,
+   **Then** the system returns `InvalidArgument` listing both missing fields
+   in a single error message.
+
+4. **Given** a Calculator with a cached client,
+   **When** a request is received with provider "gcp" (not "azure"),
+   **Then** the system returns `Unimplemented` indicating the provider is
+   unsupported (maps through `ErrUnsupportedResourceType`).
+
+5. **Given** a Calculator with a cached client,
+   **When** a request is received with an unsupported resource type (e.g.,
+   "network/LoadBalancer"),
+   **Then** the system returns `Unimplemented` indicating the resource type
+   is not supported.
+
+6. **Given** a Calculator with a cached client,
+   **When** a request is received with a nil resource descriptor,
+   **Then** the system returns `InvalidArgument`.
+
+---
+
+### User Story 3 - Structured Observability (Priority: P2)
+
+An operator monitoring the plugin can observe structured log entries for every
+`GetProjectedCost` request — including request parameters on entry, pricing
+results on success, and categorized failure information on errors — enabling
+effective debugging and alerting.
+
+**Why this priority**: Observability is critical for production operation but
+is not user-facing functionality. It follows the existing `EstimateCost`
+pattern already established in the codebase.
+
+**Independent Test**: Can be tested by capturing log output during request
+processing and asserting that structured fields (region, sku, resource_type,
+provider, result_status, cost_per_month, currency) appear at the correct
+log levels.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Calculator processing a valid projected cost request,
+   **When** the request is received,
+   **Then** an Info-level log entry includes `region`, `sku`,
+   `resource_type`, and `provider` fields.
+
+2. **Given** a Calculator processing a valid projected cost request,
+   **When** the request succeeds,
+   **Then** an Info-level log entry includes `cost_per_month`, `currency`,
+   `unit_price`, and `result_status=success`.
+
+3. **Given** a Calculator processing a request with missing fields,
+   **When** validation fails,
+   **Then** a Warn-level log entry includes `result_status=error` and the
+   validation error.
+
+4. **Given** a Calculator processing a valid request,
+   **When** the Azure API or cache lookup fails,
+   **Then** an Error-level log entry includes `result_status=error` and the
+   API error details.
+
+---
+
+### User Story 4 - Graceful Degradation Without Cache (Priority: P3)
+
+When the cached client is not configured (nil), the system returns a clear
+`Unimplemented` status indicating the functionality is unavailable, rather
+than panicking or returning an ambiguous error.
+
+**Why this priority**: This is a defensive guard for deployment scenarios
+where the cache layer is not initialized. It preserves the existing behavior
+while making it explicit.
+
+**Independent Test**: Can be tested by creating a Calculator without a cached
+client and sending a valid projected cost request.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Calculator without a cached client (nil),
+   **When** any `GetProjectedCost` request is received,
+   **Then** the system returns `Unimplemented` with a descriptive message.
+
+### Edge Cases
+
+- What happens when Azure API returns an empty price list for a valid
+  region/SKU combination? The system propagates `NotFound` via
+  `MapToGRPCStatus`.
+- What happens when the resource descriptor has valid region/SKU in tags
+  but not in primary fields? The `MapDescriptorToQuery` function falls back
+  to tags, so the request succeeds.
+- What happens when provider is "Azure" (capitalized)? Provider matching is
+  case-insensitive, so it succeeds.
+- What happens when resource type includes the full URN format (e.g.,
+  "azure:compute/virtualMachine:VirtualMachine")? The mapper does NOT
+  parse URN format — it performs a direct lowercase lookup. Consumers
+  must use the short form (e.g., "compute/VirtualMachine").
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST validate the resource descriptor using
+  `MapDescriptorToQuery()` and return specific gRPC error codes based on
+  sentinel errors (`ErrMissingRequiredFields` → `InvalidArgument`,
+  `ErrUnsupportedResourceType` → `Unimplemented`).
+- **FR-002**: System MUST return `InvalidArgument` when region and/or SKU
+  are missing, with the specific field names listed in the error message.
+- **FR-003**: System MUST return `Unimplemented` when the provider is
+  not "azure" (case-insensitive comparison), since the plugin does not
+  implement non-Azure providers.
+- **FR-004**: System MUST return `Unimplemented` for resource types not
+  in the supported set (compute/VirtualMachine, storage/ManagedDisk,
+  storage/BlobStorage).
+- **FR-005**: System MUST return `Unimplemented` when the cached client is
+  nil (no pricing data source available).
+- **FR-006**: System MUST set `pricing_category` to
+  `FOCUS_PRICING_CATEGORY_STANDARD` on all successful responses.
+- **FR-007**: System MUST set `billing_detail` with a human-readable
+  explanation including the data source, SKU, region, unit rate, and
+  calculation method (e.g., hourly rate × 730 hours/month).
+- **FR-008**: System MUST propagate `expires_at` from the cache layer's
+  `CachedResult.ExpiresAt` field on successful responses.
+- **FR-009**: System MUST map all `azureclient` errors through
+  `MapToGRPCStatus()` to produce appropriate gRPC status codes.
+- **FR-010**: System MUST emit structured log entries at request entry
+  (Info level) with `region`, `sku`, `resource_type`, and `provider` fields.
+- **FR-011**: System MUST emit structured log entries on success (Info level)
+  with `cost_per_month`, `currency`, `unit_price`, and `result_status=success`.
+- **FR-012**: System MUST emit structured log entries on validation failure
+  (Warn level) with `result_status=error`.
+- **FR-013**: System MUST emit structured log entries on API/cache failure
+  (Error level) with `result_status=error`.
+- **FR-014**: System MUST return `InvalidArgument` when the resource
+  descriptor is nil.
+
+### Key Entities
+
+- **ResourceDescriptor**: The input entity containing provider, region, SKU,
+  resource type, and optional tags. Used to identify the Azure resource whose
+  projected cost is being requested.
+- **GetProjectedCostResponse**: The output entity containing unit_price,
+  currency, cost_per_month, billing_detail, pricing_category, and expires_at.
+  Provides the consumer with projected monthly cost and metadata.
+- **PriceQuery**: The internal entity that `MapDescriptorToQuery()` produces
+  from a ResourceDescriptor. Used to query the Azure Retail Prices API via
+  the cached client.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All valid projected cost requests return responses with all
+  five core fields populated (unit_price, currency, cost_per_month,
+  billing_detail, pricing_category) — 100% of the time.
+- **SC-002**: Validation errors identify the exact missing or invalid fields,
+  enabling consumers to correct requests without trial-and-error — every
+  error message names the specific fields.
+- **SC-003**: All existing `GetProjectedCost` tests continue to pass without
+  modification (backward compatibility preserved).
+- **SC-004**: Every `GetProjectedCost` request produces at least one
+  structured log entry with all required fields, enabling operators to
+  trace any request through the system.
+- **SC-005**: Error responses use the correct gRPC status codes
+  (`InvalidArgument`, `Unimplemented`, `NotFound`, etc.) matching the
+  established `EstimateCost` error handling pattern.
+
+## Constitution Compliance *(mandatory)*
+
+### Quality Standards
+
+- [x] Feature requirements include test coverage expectations (≥80% for business logic)
+- [x] Error handling strategy is defined (no silent failures)
+- [x] Code complexity is considered (functions <15 cyclomatic complexity)
+
+### Testing Requirements
+
+- [x] Test scenarios defined for all user stories (Given/When/Then format)
+- [x] Integration test needs identified (existing integration tests in `examples/`)
+- [x] Performance test criteria specified (if applicable)
+
+### User Experience
+
+- [x] Error messages are user-friendly and actionable
+- [x] Response time expectations defined (cache hits <10ms, API calls <2s p95)
+- [x] Observability requirements specified (logging, metrics)
+
+### Documentation
+
+- [x] README.md updates identified (if user-facing changes)
+- [x] API documentation needs outlined (godoc comments, contracts)
+- [x] Docstring coverage ≥80% maintained (all exported symbols documented)
+- [x] Examples/quickstart guide planned (if new capability)
+
+### Performance & Reliability
+
+- [x] Performance targets specified (response times, throughput)
+- [x] Reliability requirements defined (retry logic, error handling)
+- [x] Resource constraints considered (memory, connections, cache TTL)
+
+### Architectural Constraints Check
+
+- [x] DOES NOT require authenticated Azure APIs
+- [x] DOES NOT introduce persistent storage
+- [x] DOES NOT mutate infrastructure
+- [x] DOES NOT embed bulk pricing data
+
+## Assumptions
+
+- The existing `MapDescriptorToQuery()` function in `mapper.go` provides
+  sufficient validation for all resource types, including correct sentinel
+  error mapping.
+- The `billing_detail` string format is informational only and not parsed
+  by consumers — its exact format may evolve.
+- VM projected cost uses the same hourly-to-monthly conversion as
+  `EstimateCost` (unit_price × 730 hours/month).
+- The `projectedQueryFromRequest()` function will be refactored to use
+  `MapDescriptorToQuery()` internally, replacing the current boolean-return
+  pattern.
+- Managed Disk and Blob Storage resource types are validated by the mapper
+  but their full projected cost paths may remain stubs until separate
+  feature work is completed.
+
+## Dependencies
+
+- Depends on: Issue #17 (VM cost estimation pattern — already completed)
+- Blocked by: none (all infrastructure exists)
+- SDK dependency: `finfocus-spec v0.5.7` (pluginsdk response helpers)

--- a/specs/023-projected-cost-rpc/tasks.md
+++ b/specs/023-projected-cost-rpc/tasks.md
@@ -1,0 +1,187 @@
+# Tasks: GetProjectedCost RPC
+
+**Input**: Design documents from `/specs/023-projected-cost-rpc/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included per constitution (TDD requirement — tests MUST be written BEFORE implementation).
+
+**Organization**: Tasks grouped by user story. US1 (VM Cost Lookup) and US2 (Validation Errors) are combined because they share the same implementation function (`GetProjectedCost()`).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Verify existing infrastructure supports the feature
+
+- [x] T001 Verify `MapDescriptorToQuery()` returns sentinel errors for all validation cases by reading `internal/pricing/mapper.go` and `internal/pricing/mapper_test.go`
+- [x] T002 Verify `MapToGRPCStatus()` maps `ErrUnsupportedResourceType` and `ErrMissingRequiredFields` to correct gRPC codes by reading `internal/pricing/errors.go` and `internal/pricing/errors_test.go`
+- [x] T003 Verify pluginsdk helpers `WithProjectedCostDetails()`, `WithProjectedCostPricingCategory()`, `WithProjectedCostExpiresAt()` exist and accept expected parameters
+
+**Checkpoint**: All existing infrastructure confirmed — no new dependencies needed
+
+---
+
+## Phase 2: US1+US2 — VM Cost Lookup + Validation Error Feedback (Priority: P1) MVP
+
+**Goal**: Refactor `GetProjectedCost` to use `MapDescriptorToQuery()` for validation, return complete responses with `billing_detail` and `pricing_category`, and provide specific gRPC error codes for all invalid inputs.
+
+**Independent Test**: Send a valid VM request and verify all 5 response fields; send invalid requests and verify specific gRPC codes with field names in error messages.
+
+### Tests for US1+US2 (TDD Red — write first, verify they fail)
+
+- [x] T004 [US1] [US2] Write table-driven `TestGetProjectedCost_Validation` test with cases for nil request, nil descriptor, wrong provider, unsupported resource type, missing region, missing SKU, missing both, nil cachedClient in `internal/pricing/calculator_test.go`
+- [x] T005 [US1] Write `TestGetProjectedCost_Success_VMResponse` test asserting unit_price, currency, cost_per_month, billing_detail, pricing_category, and expires_at are all set correctly in `internal/pricing/calculator_test.go`
+- [x] T006 [US1] Write `TestGetProjectedCost_Success_BillingDetail` test asserting billing_detail format matches `"Azure Retail Prices API: {SKU} in {region} at ${price}/hr * 730 hrs/mo"` in `internal/pricing/calculator_test.go`
+- [x] T007 [US1] Write `TestGetProjectedCost_APIError` test asserting Azure API errors are mapped through `MapToGRPCStatus()` to correct gRPC codes in `internal/pricing/calculator_test.go`
+
+### Implementation for US1+US2 (TDD Green)
+
+- [x] T008 [US1] [US2] Refactor `GetProjectedCost()` in `internal/pricing/calculator.go`: replace `projectedQueryFromRequest()` call with `MapDescriptorToQuery(req.GetResource())`, add nil request/descriptor guard, map errors via `MapToGRPCStatus()`
+- [x] T009 [US1] [US2] Add resource-type routing after `MapDescriptorToQuery()` succeeds: VM service name → compute cost path, Managed Disks/Storage → return `codes.Unimplemented` with descriptive message in `internal/pricing/calculator.go`
+- [x] T010 [US1] Build response with `WithProjectedCostDetails(unitPrice, currency, costMonthly, billingDetail)`, `WithProjectedCostPricingCategory(STANDARD)`, `WithProjectedCostExpiresAt()` in `internal/pricing/calculator.go`
+- [x] T011 [US1] Update `TestGetProjectedCostSetsExpiresAtFromCache` to use resource type `"compute/VirtualMachine"` instead of `"azure:compute/virtualMachine:VirtualMachine"` in `internal/pricing/calculator_test.go`
+- [x] T012 [US1] Rewrite `TestProjectedCostSupported` to use Azure provider/resource type (`provider="azure"`, `resource_type="compute/VirtualMachine"`, `region="eastus"`, `sku="Standard_B1s"`) replacing the AWS placeholder data, remove `t.Skip()`, and verify it passes in `internal/pricing/calculator_test.go`
+- [x] T013 [US1] [US2] Remove now-unused `projectedQueryFromRequest()` function from `internal/pricing/calculator.go` after verifying no other callers via grep
+- [x] T014 Run `make test` to verify all tests pass including existing `TestGetProjectedCostReturnsUnimplemented` (US4 backward compat)
+
+**Checkpoint**: US1+US2 complete — VM projected cost returns all fields, all validation errors return specific gRPC codes. US4 (nil cachedClient) also verified.
+
+---
+
+## Phase 3: US3 — Structured Observability (Priority: P2)
+
+**Goal**: Add zerolog structured logging at all decision points in `GetProjectedCost`, matching the `EstimateCost` pattern.
+
+**Independent Test**: Capture log output during request processing and verify structured fields appear at correct log levels.
+
+### Tests for US3 (TDD Red — write first, verify they fail)
+
+- [x] T015a [US3] Write `TestGetProjectedCost_Logging` table-driven test capturing zerolog output (via `zerolog.New(&buf)`) and asserting: (a) success path emits Info with `cost_monthly`, `currency`, `unit_price`, `result_status=success`; (b) validation failure emits Warn with `result_status=error`; (c) API failure emits Error with `result_status=error`; (d) nil cachedClient emits Warn with `result_status=error` in `internal/pricing/calculator_test.go`
+
+### Implementation for US3
+
+- [x] T015 [US3] Add request entry log (Info level) with `region`, `sku`, `resource_type`, `provider` fields after `MapDescriptorToQuery()` succeeds in `internal/pricing/calculator.go`
+- [x] T016 [US3] Add validation failure log (Warn level) with `result_status=error` for nil descriptor, mapper errors, and unsupported resource types in `internal/pricing/calculator.go`
+- [x] T017 [US3] Add API/cache failure log (Error level) with `region`, `sku`, `resource_type`, `result_status=error` for `GetPrices()` and `unitPriceAndCurrency()` failures in `internal/pricing/calculator.go`
+- [x] T018 [US3] Add success log (Info level) with `region`, `sku`, `resource_type`, `cost_monthly`, `currency`, `unit_price`, `result_status=success` in `internal/pricing/calculator.go`
+- [x] T019 [US3] Add cachedClient nil guard log (Warn level) with `result_status=error` in `internal/pricing/calculator.go`
+- [x] T020 Run `make test` to verify logging additions don't break existing tests
+
+**Checkpoint**: All `GetProjectedCost` code paths produce structured log entries at correct severity levels.
+
+---
+
+## Phase 4: US4 — Graceful Degradation Without Cache (Priority: P3)
+
+**Goal**: Verify the nil cachedClient guard returns `Unimplemented` with a descriptive message. This behavior already exists from the current implementation; this phase confirms it survives refactoring.
+
+**Independent Test**: Create Calculator without cached client, send valid request, assert `Unimplemented`.
+
+- [x] T021 [US4] Verify `TestGetProjectedCostReturnsUnimplemented` still passes after all refactoring by running `go test -run TestGetProjectedCostReturnsUnimplemented -v ./internal/pricing/`
+
+**Checkpoint**: US4 confirmed — nil cachedClient returns Unimplemented with logging.
+
+---
+
+## Phase 5: Polish and Cross-Cutting Concerns
+
+**Purpose**: Documentation, quality gates, and final validation
+
+### Constitution Compliance Tasks
+
+- [x] T022 [P] Update godoc comment on `GetProjectedCost()` method to document supported resource types, error codes, and response fields in `internal/pricing/calculator.go`
+- [x] T023 [P] Update CLAUDE.md with `GetProjectedCost` section documenting response fields, supported resource types, error codes, and attribute aliases
+- [x] T024 [P] Run `make lint` and fix all linting issues (use extended timeout >5min)
+- [x] T025 [P] Run `make test` with race detector to verify thread safety
+- [x] T026 Verify docstring coverage ≥80% for `internal/pricing` package
+
+### Quality Gates
+
+- [x] T027 Run `make build` and verify success
+- [x] T028 Run full `make test` and verify all tests pass
+- [x] T029 Verify no new files need to be added to `.gitignore`
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — verification only
+- **Phase 2 (US1+US2)**: Depends on Phase 1 confirmation — BLOCKS all subsequent phases
+- **Phase 3 (US3)**: Depends on Phase 2 (logging attaches to refactored code paths)
+- **Phase 4 (US4)**: Depends on Phase 2 (verifies refactoring preserved guard)
+- **Phase 5 (Polish)**: Depends on Phases 2, 3, 4
+
+### User Story Dependencies
+
+- **US1+US2 (P1)**: Can start after Phase 1 — no dependencies on other stories
+- **US3 (P2)**: Depends on US1+US2 (logging hooks into the refactored code)
+- **US4 (P3)**: Depends on US1+US2 (verifies guard survives refactoring)
+- US3 and US4 can run in parallel after US1+US2 completes
+
+### Within Phase 2 (US1+US2)
+
+- T004-T007 (tests) MUST be written first and FAIL before T008
+- T008-T010 (implementation) are sequential within the same function
+- T011-T012 (fixture fixes) depend on T008 (refactored code)
+- T013 (dead code removal) depends on T011-T012 (all callers migrated)
+- T014 (full test run) depends on all above
+
+### Parallel Opportunities
+
+```text
+Phase 2 tests (can run in parallel since they're in the same file
+but test different scenarios — write all before implementing):
+  T004 (validation table) || T005 (success) || T006 (billing_detail) || T007 (API error)
+
+Phase 3 logging (test first, then sequential implementation):
+  T015a (test) → T015 → T016 → T017 → T018 → T019
+
+Phase 5 polish (all parallel — different files/concerns):
+  T022 || T023 || T024 || T025 || T026
+```
+
+---
+
+## Parallel Example: Phase 2 Tests
+
+```text
+# Write all test functions in parallel (same file, different test functions):
+T004: "Table-driven validation test in internal/pricing/calculator_test.go"
+T005: "Success response test in internal/pricing/calculator_test.go"
+T006: "billing_detail format test in internal/pricing/calculator_test.go"
+T007: "API error propagation test in internal/pricing/calculator_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 2: US1+US2 Only)
+
+1. Complete Phase 1: Verify infrastructure (read-only)
+2. Complete Phase 2: US1+US2 — TDD tests then implementation
+3. **STOP and VALIDATE**: `make test` passes, VM projected cost works
+4. This alone delivers the core value: production-ready GetProjectedCost
+
+### Incremental Delivery
+
+1. Phase 2 (US1+US2) → Core functionality (MVP)
+2. Phase 3 (US3) → Observability (production readiness)
+3. Phase 4 (US4) → Guard verification (confidence)
+4. Phase 5 (Polish) → Documentation and quality gates
+
+---
+
+## Notes
+
+- US1 and US2 are combined because they share `GetProjectedCost()` — validation errors and success path are branches of the same function
+- US4 is minimal because the nil cachedClient guard already exists; this phase just confirms it survives refactoring
+- All test tasks follow TDD: write tests first, verify they fail, then implement
+- The `projectedQueryFromRequest()` removal (T013) is the final step after all consumers are migrated
+- Logging (Phase 3) is separated from implementation (Phase 2) to keep each phase focused and reviewable


### PR DESCRIPTION
## Summary

- Refactor `GetProjectedCost` from a partial stub into a production-ready RPC using `MapDescriptorToQuery()` for validation with sentinel errors mapped to specific gRPC codes
- Replace boolean-return `projectedQueryFromRequest()` with rich error propagation: `InvalidArgument` for missing fields, `Unimplemented` for unsupported providers/types, `NotFound` for missing pricing data
- Add resource-type routing: VMs compute hourly×730 monthly cost, disk/blob types validate but return `Unimplemented`
- Build responses with SDK helpers including `billing_detail`, `pricing_category` (STANDARD), and cache `expires_at`
- Add structured zerolog logging at all decision points matching the `EstimateCost` observability pattern

## Test plan

- [x] `TestGetProjectedCost_Validation` — 8 table-driven cases covering nil request, nil descriptor, wrong provider, unsupported type, missing region/sku/both, nil cachedClient
- [x] `TestGetProjectedCost_Success_VMResponse` — all 6 response fields validated
- [x] `TestGetProjectedCost_Success_BillingDetail` — exact format string assertion
- [x] `TestGetProjectedCost_APIError` — error propagation through `MapToGRPCStatus()`
- [x] `TestGetProjectedCost_Logging` — 4 cases validating log levels (Info/Warn/Error) and structured fields
- [x] `TestGetProjectedCostReturnsUnimplemented` — US4 graceful degradation preserved after refactoring
- [x] `TestProjectedCostSupported` — rewritten with Azure data, `t.Skip()` removed
- [x] `make build` passes
- [x] `make test` passes with race detector
- [x] `make lint` passes with 0 issues

## Changes

### Modified files

- `internal/pricing/calculator.go` — Refactored `GetProjectedCost` to use `MapDescriptorToQuery()`, added resource-type routing, structured logging, billing detail format; removed unused `projectedQueryFromRequest()`
- `internal/pricing/calculator_test.go` — Added 4 new test functions (15 test cases total), fixed 3 existing test fixtures to use correct resource type format and Azure data
- `CLAUDE.md` — Added GetProjectedCost RPC documentation section
- `internal/azureclient/logger.go` — Removed stale nolint directive

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GetProjectedCost RPC is now fully functional for Azure virtual machines, supporting projected monthly cost retrieval.
  * Enhanced validation and error handling with improved gRPC status codes for validation and API errors.
  * Added structured logging for better observability.

* **Documentation**
  * Added comprehensive specification, contract, data model, and quickstart documentation for the GetProjectedCost RPC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->